### PR TITLE
[Feature/11] 디자이너의 견적서 작성 관련 API 추가

### DIFF
--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/config/SecurityConfig.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/config/SecurityConfig.java
@@ -62,7 +62,7 @@ public class SecurityConfig{
                                 "/reform/purchaser/requests/**",
                                 "/chat/**", "/chat","/chatroom").hasRole("PURCHASER")
                         .requestMatchers("/auth/update-designer/address","/designer/portfolio/**",
-                                "/chat/**", "/chat","/chatroom").hasRole("DESIGNER")
+                                "/chat/**", "/chat","/chatroom", "/estimate/designer/estimateForm/**").hasRole("DESIGNER")
                         .anyRequest().authenticated());
 
         http

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/controller/estimate/EstimateController.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/controller/estimate/EstimateController.java
@@ -2,6 +2,7 @@ package com.jjs.ClothingInventorySaleReformPlatform.controller.estimate;
 
 import com.jjs.ClothingInventorySaleReformPlatform.dto.estimate.ClientResponse;
 import com.jjs.ClothingInventorySaleReformPlatform.dto.estimate.request.EstimateRequestDTO;
+import com.jjs.ClothingInventorySaleReformPlatform.dto.estimate.response.EstimateResponseDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.dto.reformrequest.ReformRequestResponseDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.dto.response.Response;
 import com.jjs.ClothingInventorySaleReformPlatform.service.estimate.EstimateService;
@@ -64,6 +65,13 @@ public class EstimateController {
             log.error("리폼 요청 사항 저장 에러",e);
             return response.fail(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
+    }
+
+    @GetMapping(value = "/estimate/designer/estimateForm/{estimateNumber}")
+    @Operation(summary = "디자이너의 견적서 조회", description = "디자이너가 견적서를 수정할 때, 기존의 정보를 불러오는 용도로 사용한다.")
+    public ResponseEntity<?> getEstimateDetails(@PathVariable Long estimateNumber) {
+        EstimateResponseDTO estimateResponseDTO = estimateService.getEstimate(estimateNumber);
+        return response.success(estimateResponseDTO, "견적서 조회 성공", HttpStatus.OK);
     }
 
 

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/controller/estimate/EstimateController.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/controller/estimate/EstimateController.java
@@ -1,6 +1,7 @@
 package com.jjs.ClothingInventorySaleReformPlatform.controller.estimate;
 
 import com.jjs.ClothingInventorySaleReformPlatform.dto.estimate.ClientResponse;
+import com.jjs.ClothingInventorySaleReformPlatform.dto.estimate.request.EstimateRequestDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.dto.reformrequest.ReformRequestResponseDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.dto.response.Response;
 import com.jjs.ClothingInventorySaleReformPlatform.service.estimate.EstimateService;
@@ -9,6 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -50,6 +52,18 @@ public class EstimateController {
         }
 
         return response.success("상태 변경 완료.");
+    }
+
+    @PostMapping(value = "/estimate/designer/estimateForm/{requestNumber}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(summary = "디자이너의 견적서 작성", description = "디자이너가 견적서를 작성합니다.")
+    public ResponseEntity<?> sendEstimate(@ModelAttribute EstimateRequestDTO estimateRequestDTO, @PathVariable Long requestNumber) {
+        try {
+            estimateService.saveEstimate(estimateRequestDTO, requestNumber);
+            return response.success("견적서 등록 성공.", HttpStatus.OK);
+        } catch (Exception e) {
+            log.error("리폼 요청 사항 저장 에러",e);
+            return response.fail(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
 

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/controller/estimate/EstimateController.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/controller/estimate/EstimateController.java
@@ -70,11 +70,33 @@ public class EstimateController {
     @GetMapping(value = "/estimate/designer/estimateForm/{estimateNumber}")
     @Operation(summary = "디자이너의 견적서 조회", description = "디자이너가 견적서를 수정할 때, 기존의 정보를 불러오는 용도로 사용한다.")
     public ResponseEntity<?> getEstimateDetails(@PathVariable Long estimateNumber) {
-        EstimateResponseDTO estimateResponseDTO = estimateService.getEstimate(estimateNumber);
-        return response.success(estimateResponseDTO, "견적서 조회 성공", HttpStatus.OK);
+        try {
+            EstimateResponseDTO estimateResponseDTO = estimateService.getEstimate(estimateNumber);
+            return response.success(estimateResponseDTO, "견적서 조회 성공", HttpStatus.OK);
+        } catch (Exception e) {
+            log.error("견적서 조회 실패", e);
+            return response.fail("견적서 조회 실패", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
     }
 
-
+    @PutMapping(value = "/estimate/designer/estimateForm/{estimateNumber}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(summary = "디자이너의 견적서 수정", description = "디자이너가 견적서를 수정한다. getEstimateDetails으로 조회하고 수정하면 전체 내용이 덮어쓰기 형식으로 저장된다.")
+    public ResponseEntity<?> updateEstimateDetails(@PathVariable Long estimateNumber, @ModelAttribute EstimateRequestDTO estimateRequestDTO) {
+        try {
+            estimateService.updateEstimate(estimateRequestDTO, estimateNumber);
+            return response.success("의뢰 수정 성공", HttpStatus.OK);
+        } catch (IllegalArgumentException e) {
+            log.error(e.getMessage());
+            return response.fail("의뢰 수정 실패", HttpStatus.INTERNAL_SERVER_ERROR);
+        } catch (RuntimeException e) {
+            log.error(e.getMessage());
+            return response.fail("의뢰 수정 실패", HttpStatus.INTERNAL_SERVER_ERROR);
+        } catch (Exception e) {
+            log.error(e.getMessage());
+            return response.fail("의뢰 수정 실패", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
 
 }
 

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/estimate/Estimate.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/estimate/Estimate.java
@@ -1,6 +1,8 @@
 package com.jjs.ClothingInventorySaleReformPlatform.domain.estimate;
 
 import com.jjs.ClothingInventorySaleReformPlatform.domain.reformrequest.ReformRequest;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.reformrequest.ReformRequestImage;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.reformrequest.ReformRequestStatus;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.user.DesignerInfo;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.user.PurchaserInfo;
 import jakarta.persistence.*;
@@ -8,30 +10,30 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Getter
 @Setter
 @Entity
 @Table(name = "ESTIMATE")
 public class Estimate {  // 견적서
 
-    // 견적서번호, 의뢰번호, 의뢰자이메일, 디자이너이메일, 견적서정보, 견적서사진, 가격
+    // 견적서번호, 견적서정보, 사진, 가격, 의뢰자이메일, 디자이너이메일, 의뢰번호, 견적서 상태,
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "ESTIMATE_NUMBER", nullable = false)
-    private Integer id;  // 견적서 번호
+    private Long id;  // 견적서 번호
 
-    @NotNull
-    @Column(name = "ESTIMATE_INFO", nullable = false, length = 1000)
-    private String estimateInfo;  // 견적서 정보
+    @Column(name = "ESTIMATE_INFO", nullable = false, length = 2000)
+    private String estimateInfo;  // 견적서 정보(상세글)
 
-    @NotNull
-    @Column(name = "ESTIMATE_IMG", nullable = false)
-    private byte[] estimateImg;  // 견적서 사진
+    @OneToMany(mappedBy = "estimate", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY) // 리폼 의뢰 첨부 이미지 연결
+    private List<EstimateImage> estimateImg = new ArrayList<>();
 
-    @NotNull
     @Column(name = "PRICE", nullable = false)
-    private Integer price;  // 가격
+    private String price;  // 가격
 
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
@@ -48,21 +50,7 @@ public class Estimate {  // 견적서
     @JoinColumn(name = "REQUEST_NUMBER", nullable = false)
     private ReformRequest requestNumber;  // 의뢰 번호
 
-    /*
+    @Enumerated(EnumType.STRING)
+    private EstimateStatus estimateStatus;  // 견적서 상태 REQUEST_WAITING, REQUEST_REJECTED, REQUEST_ACCEPTED
 
-    // 김영한 jpa 방식으로 수정 - 4
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "EMAIL")
-    private Seller clientEmail2;
-
-
-    @OneToMany(mappedBy = "estimateNumber")
-    private Set<Completelist> completelists = new LinkedHashSet<>();
-
-    @OneToMany(mappedBy = "estimateNumber")
-    private Set<Progressmanagement> progressmanagements = new LinkedHashSet<>();
-
-    @OneToMany(mappedBy = "estimateNumber")
-    private Set<Question> questions = new LinkedHashSet<>();
-*/
 }

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/estimate/Estimate.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/estimate/Estimate.java
@@ -22,8 +22,7 @@ public class Estimate {  // 견적서
     private Integer id;  // 견적서 번호
 
     @NotNull
-    @Lob
-    @Column(name = "ESTIMATE_INFO", nullable = false)
+    @Column(name = "ESTIMATE_INFO", nullable = false, length = 1000)
     private String estimateInfo;  // 견적서 정보
 
     @NotNull

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/estimate/EstimateImage.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/estimate/EstimateImage.java
@@ -1,0 +1,26 @@
+package com.jjs.ClothingInventorySaleReformPlatform.domain.estimate;
+
+import com.jjs.ClothingInventorySaleReformPlatform.common.entity.BaseEntity;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.reformrequest.ReformRequest;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "ESTIMATE_IMAGE")
+public class EstimateImage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ESTIMATE_IMG_NUMBER", nullable = false)
+    private Long id;  // 견적서 이미지 번호
+
+    @Column(name = "ESTIMATE_IMG", nullable = false)
+    private String imgUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "ESTIMATE_NUMBER")
+    private Estimate estimate;
+}

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/estimate/EstimateStatus.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/estimate/EstimateStatus.java
@@ -1,0 +1,5 @@
+package com.jjs.ClothingInventorySaleReformPlatform.domain.estimate;
+
+public enum EstimateStatus {
+    REQUEST_WAITING, REQUEST_REJECTED, REQUEST_ACCEPTED // 요청 대기중, 요청 거절, 요청 수락
+}

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/Portfolio.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/Portfolio.java
@@ -26,8 +26,7 @@ public class Portfolio extends BaseEntity {  // 포트폴리오 - 디자이너�
     private String name;
 
     @NotNull
-    @Lob
-    @Column(name = "EXPLANATION", nullable = false)
+    @Column(name = "EXPLANATION", nullable = false, length = 1000)  // @Lob는 매우 큰 데이터(Mb 단위)를 저장할 때 사용한다고 하여 varchar(1000)으로 수정함
     private String explanation;  // 설명
 
     @NotNull

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/product/Product.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/product/Product.java
@@ -32,7 +32,7 @@ public class Product extends BaseEntity {  // BaseEntity가 등록시간, 수정
     @Column(nullable = false)
     private int productStock;  // 재고수
 
-    @Column
+    @Column(length = 1000)
     private String productDetailText;  // 상품 설명(보류)
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/reformrequest/ReformRequest.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/reformrequest/ReformRequest.java
@@ -23,8 +23,7 @@ public class ReformRequest extends BaseEntity {  // 의뢰서 - 의뢰번호, �
     private Long id;  // 의뢰 번호
 
     @NotNull
-    @Lob
-    @Column(name = "REQUEST_INFO", nullable = false)
+    @Column(name = "REQUEST_INFO", nullable = false, length = 1000)
     private String requestInfo;  // 의뢰 정보
 
     @NotNull

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/dto/estimate/request/EstimateRequestDTO.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/dto/estimate/request/EstimateRequestDTO.java
@@ -1,0 +1,19 @@
+package com.jjs.ClothingInventorySaleReformPlatform.dto.estimate.request;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class EstimateRequestDTO {
+
+    private String estimateInfo;  // 의뢰 정보(내용)
+
+    private List<MultipartFile> estimateImg;  // 의뢰 사진
+
+    private String price; // 희망 가격
+
+}

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/dto/estimate/response/EstimateResponseDTO.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/dto/estimate/response/EstimateResponseDTO.java
@@ -1,0 +1,31 @@
+package com.jjs.ClothingInventorySaleReformPlatform.dto.estimate.response;
+
+import com.jjs.ClothingInventorySaleReformPlatform.domain.estimate.EstimateImage;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.estimate.EstimateStatus;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.reformrequest.ReformRequest;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.user.DesignerInfo;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.user.PurchaserInfo;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+public class EstimateResponseDTO {
+
+    private Long id;  // 견적서 번호
+    private String clientEmail;  // 의뢰자 이메일
+    private String designerEmail;  // 디자이너 이메일
+    private String estimateInfo;  // 의뢰 정보(내용)
+    private String price; // 희망 가격
+    private String estimateImg;  // 의뢰 사진
+    private Long requestNumber;  // 의뢰서 번호
+
+
+    private String estimateStatus;  // 견적서 상태 REQUEST_WAITING, REQUEST_REJECTED, REQUEST_ACCEPTED
+}

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/repository/estimate/EstimateImgRepository.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/repository/estimate/EstimateImgRepository.java
@@ -1,0 +1,9 @@
+package com.jjs.ClothingInventorySaleReformPlatform.repository.estimate;
+
+import com.jjs.ClothingInventorySaleReformPlatform.domain.estimate.EstimateImage;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.reformrequest.ReformRequestImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EstimateImgRepository extends JpaRepository<EstimateImage, Long> {
+
+}

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/repository/estimate/EstimateImgRepository.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/repository/estimate/EstimateImgRepository.java
@@ -4,6 +4,10 @@ import com.jjs.ClothingInventorySaleReformPlatform.domain.estimate.EstimateImage
 import com.jjs.ClothingInventorySaleReformPlatform.domain.reformrequest.ReformRequestImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface EstimateImgRepository extends JpaRepository<EstimateImage, Long> {
 
+    List<EstimateImage> findAllByEstimateId(Long estimateNumber);
+    public void deleteByEstimateId(Long estimateNumber);
 }

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/repository/estimate/EstimateRepository.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/repository/estimate/EstimateRepository.java
@@ -3,6 +3,8 @@ package com.jjs.ClothingInventorySaleReformPlatform.repository.estimate;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.estimate.Estimate;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface EstimateRepository extends JpaRepository<Estimate, Long> {
-    Estimate findEstimateById(Long id);
+    Optional<Estimate> findEstimateById(Long id);
 }

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/repository/estimate/EstimateRepository.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/repository/estimate/EstimateRepository.java
@@ -4,5 +4,5 @@ import com.jjs.ClothingInventorySaleReformPlatform.domain.estimate.Estimate;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EstimateRepository extends JpaRepository<Estimate, Long> {
-
+    Estimate findEstimateById(Long id);
 }

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/service/estimate/EstimateService.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/service/estimate/EstimateService.java
@@ -8,8 +8,8 @@ import com.jjs.ClothingInventorySaleReformPlatform.domain.estimate.EstimateStatu
 import com.jjs.ClothingInventorySaleReformPlatform.domain.reformrequest.ReformRequest;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.reformrequest.ReformRequestStatus;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.user.DesignerInfo;
-import com.jjs.ClothingInventorySaleReformPlatform.domain.user.PurchaserInfo;
 import com.jjs.ClothingInventorySaleReformPlatform.dto.estimate.request.EstimateRequestDTO;
+import com.jjs.ClothingInventorySaleReformPlatform.dto.estimate.response.EstimateResponseDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.dto.reformrequest.ReformRequestResponseDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.repository.estimate.EstimateImgRepository;
 import com.jjs.ClothingInventorySaleReformPlatform.repository.estimate.EstimateRepository;
@@ -138,6 +138,22 @@ public class EstimateService {
                 throw new RuntimeException("이미지가 없습니다.");
             }
         });
+    }
+
+    @Transactional
+    public EstimateResponseDTO getEstimate(Long estimateNumber) {
+        Estimate estimateById = estimateRepository.findEstimateById(estimateNumber);
+        EstimateResponseDTO estimateResponseDTO = new EstimateResponseDTO();
+        estimateResponseDTO.setId(estimateById.getId());
+        estimateResponseDTO.setClientEmail(estimateById.getClientEmail().getEmail());
+        estimateResponseDTO.setDesignerEmail(estimateById.getDesignerEmail().getEmail());
+        estimateResponseDTO.setEstimateInfo(estimateById.getEstimateInfo());
+        estimateResponseDTO.setPrice(estimateById.getPrice());
+        estimateResponseDTO.setEstimateImg(estimateById.getEstimateImg().get(0).getImgUrl());
+        estimateResponseDTO.setRequestNumber(estimateById.getRequestNumber().getId());
+        estimateResponseDTO.setEstimateStatus(estimateById.getEstimateStatus().name());
+
+        return estimateResponseDTO;
     }
 }
 

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/service/estimate/EstimateService.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/service/estimate/EstimateService.java
@@ -2,26 +2,38 @@ package com.jjs.ClothingInventorySaleReformPlatform.service.estimate;
 
 
 import com.jjs.ClothingInventorySaleReformPlatform.controller.product.AuthenticationFacade;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.estimate.Estimate;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.estimate.EstimateImage;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.estimate.EstimateStatus;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.reformrequest.ReformRequest;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.reformrequest.ReformRequestStatus;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.user.DesignerInfo;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.user.PurchaserInfo;
+import com.jjs.ClothingInventorySaleReformPlatform.dto.estimate.request.EstimateRequestDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.dto.reformrequest.ReformRequestResponseDTO;
+import com.jjs.ClothingInventorySaleReformPlatform.repository.estimate.EstimateImgRepository;
 import com.jjs.ClothingInventorySaleReformPlatform.repository.estimate.EstimateRepository;
 import com.jjs.ClothingInventorySaleReformPlatform.repository.reformrequest.ReformRequestRepository;
+import com.jjs.ClothingInventorySaleReformPlatform.service.s3.S3Service;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class EstimateService {
     private final AuthenticationFacade authenticationFacade;
+    private final S3Service s3Service;
 
     private final EstimateRepository estimateRepository;
+    private final EstimateImgRepository estimateImgRepository;
     private final ReformRequestRepository requestRepository;
 
     /**
@@ -93,6 +105,39 @@ public class EstimateService {
             throw new Exception("상태 변경에 실패하였습니다.",e);
         }
 
+    }
+
+    @Transactional
+    public void saveEstimate(EstimateRequestDTO estimateRequestDTO, Long requestNumber) {
+
+        ReformRequest reformRequest = requestRepository.findAllById(requestNumber);
+
+        Estimate estimate = new Estimate();
+        estimate.setClientEmail(reformRequest.getClientEmail());
+        estimate.setDesignerEmail(reformRequest.getDesignerEmail());
+        estimate.setRequestNumber(reformRequest);
+        estimate.setEstimateStatus(EstimateStatus.REQUEST_WAITING);
+
+        estimate.setEstimateInfo(estimateRequestDTO.getEstimateInfo());
+        estimate.setPrice(estimateRequestDTO.getPrice());
+        estimateRepository.save(estimate);
+
+        saveImageList(estimateRequestDTO, estimate);
+    }
+
+    @Transactional
+    public void saveImageList(EstimateRequestDTO estimateRequestDTO, Estimate estimate) {
+        estimateRequestDTO.getEstimateImg().forEach(image -> {
+            try {
+                EstimateImage estimateImage = new EstimateImage();
+                estimateImage.setImgUrl(s3Service.uploadFile(image, "EstimateImage/"));
+                estimateImage.setEstimate(estimate);
+                estimateImgRepository.save(estimateImage);
+            } catch (IOException e) {
+                log.error(e.getMessage());
+                throw new RuntimeException("이미지가 없습니다.");
+            }
+        });
     }
 }
 


### PR DESCRIPTION
# 🚀 개요
디자이너는 채팅을 통해 의뢰 협상을 마치고 견적서를 작성한다.

## 🔍 변경사항
- 디자이너 견적서 CRUD API 추가
- 긴 글을 작성하는 타입 https://github.com/lob -> varchar(1000~2000) 으로 변경함

## ⏳ 작업 내용
- [x] 디자이너의 견적서 작성 API 추가
- [x] 디자이너의 견적서 수정 API 추가
- [x] 디자이너의 견적서 삭제 API 추가
📚 Remarks

### 📝 논의사항

