### PR TITLE
[Feature/18] 리폼 형상관리 API 작성 

### DIFF
--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/config/SecurityConfig.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/config/SecurityConfig.java
@@ -62,7 +62,8 @@ public class SecurityConfig{
                                 "/reform/purchaser/requests/**",
                                 "/chat/**", "/chat","/chatroom", "/estimate/purchaser/**").hasRole("PURCHASER")
                         .requestMatchers("/auth/update-designer/address","/designer/portfolio/**",
-                                "/chat/**", "/chat","/chatroom", "/estimate/designer/estimateForm/**").hasRole("DESIGNER")
+                                "/chat/**", "/chat","/chatroom", "/estimate/designer/estimateForm/**",
+                                "/progress/designer/setImg/**").hasRole("DESIGNER")
                         .anyRequest().authenticated());
 
         http

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/controller/ProgressManagementController.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/controller/ProgressManagementController.java
@@ -53,4 +53,18 @@ public class ProgressManagementController {
         }
     }
 
+    @PatchMapping("/progress/designer/setImg/complete")
+    @Operation(summary = "형상관리 완료된 이미지 등록", description = "형상관리 시, 리폼 완료된 이미지를 등록하는 API 입니다.")
+    public ResponseEntity<?> setCompleteImg(ProgressImgRequestDTO imgRequestDTO) {
+        try {
+            progressManagementService.saveCompleteImg(imgRequestDTO);
+            return response.success(imgRequestDTO.getEstimateId(), "해당 견적서와 매칭되는 형상관리에 리폼 완료된 사진 등록 완료", HttpStatus.OK);
+        } catch (IllegalArgumentException e) {
+            log.error(e.getMessage());
+            return response.fail("이미지 등록 실패", HttpStatus.INTERNAL_SERVER_ERROR);
+        } catch (Exception e) {
+            log.error(e.getMessage());
+            return response.fail("이미지 등록 실패", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
 }

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/controller/ProgressManagementController.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/controller/ProgressManagementController.java
@@ -1,0 +1,18 @@
+package com.jjs.ClothingInventorySaleReformPlatform.controller;
+
+import com.jjs.ClothingInventorySaleReformPlatform.dto.response.Response;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "리폼 형상관리", description = "구매자가 디자이너가 제공한 견적서 수락 시, 진행되는 형상관리에 대한 API 입니다.")
+public class ProgressManagementController {
+
+    private final Response response;
+
+
+}

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/controller/ProgressManagementController.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/controller/ProgressManagementController.java
@@ -1,6 +1,6 @@
 package com.jjs.ClothingInventorySaleReformPlatform.controller;
 
-import com.jjs.ClothingInventorySaleReformPlatform.dto.reform.request.ProgressFirstImgRequestDTO;
+import com.jjs.ClothingInventorySaleReformPlatform.dto.reform.request.ProgressImgRequestDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.dto.response.Response;
 import com.jjs.ClothingInventorySaleReformPlatform.repository.ProgressRepository;
 import com.jjs.ClothingInventorySaleReformPlatform.service.ProgressManagementService;
@@ -23,9 +23,9 @@ public class ProgressManagementController {
     private final ProgressRepository progressRepository;
     private final ProgressManagementService progressManagementService;
 
-    @PatchMapping("/progress/designer/setImg/First")
+    @PatchMapping("/progress/designer/setImg/first")
     @Operation(summary = "형상관리 첫 번째 이미지 등록", description = "형상관리 시, 첫 번째의 리폼 중간 이미지를 등록하는 API 입니다.")
-    public ResponseEntity<?> setFirstImg(ProgressFirstImgRequestDTO imgRequestDTO) {
+    public ResponseEntity<?> setFirstImg(ProgressImgRequestDTO imgRequestDTO) {
         try {
             progressManagementService.saveFirstImg(imgRequestDTO);
             return response.success(imgRequestDTO.getEstimateId(), "해당 견적서와 매칭되는 형상관리에 첫 번째 사진 등록 완료", HttpStatus.OK);
@@ -36,7 +36,21 @@ public class ProgressManagementController {
             log.error(e.getMessage());
             return response.fail("이미지 등록 실패", HttpStatus.INTERNAL_SERVER_ERROR);
         }
+    }
 
+    @PatchMapping("/progress/designer/setImg/second")
+    @Operation(summary = "형상관리 두 번째 이미지 등록", description = "형상관리 시, 두 번째의 리폼 중간 이미지를 등록하는 API 입니다.")
+    public ResponseEntity<?> setSecondImg(ProgressImgRequestDTO imgRequestDTO) {
+        try {
+            progressManagementService.saveSecondImg(imgRequestDTO);
+            return response.success(imgRequestDTO.getEstimateId(), "해당 견적서와 매칭되는 형상관리에 두 번째 사진 등록 완료", HttpStatus.OK);
+        } catch (IllegalArgumentException e) {
+            log.error(e.getMessage());
+            return response.fail("이미지 등록 실패", HttpStatus.INTERNAL_SERVER_ERROR);
+        } catch (Exception e) {
+            log.error(e.getMessage());
+            return response.fail("이미지 등록 실패", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
 }

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/controller/ProgressManagementController.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/controller/ProgressManagementController.java
@@ -1,9 +1,16 @@
 package com.jjs.ClothingInventorySaleReformPlatform.controller;
 
+import com.jjs.ClothingInventorySaleReformPlatform.dto.reform.request.ProgressFirstImgRequestDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.dto.response.Response;
+import com.jjs.ClothingInventorySaleReformPlatform.repository.ProgressRepository;
+import com.jjs.ClothingInventorySaleReformPlatform.service.ProgressManagementService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -13,6 +20,23 @@ import org.springframework.web.bind.annotation.RestController;
 public class ProgressManagementController {
 
     private final Response response;
+    private final ProgressRepository progressRepository;
+    private final ProgressManagementService progressManagementService;
 
+    @PatchMapping("/progress/designer/setImg/First")
+    @Operation(summary = "형상관리 첫 번째 이미지 등록", description = "형상관리 시, 첫 번째의 리폼 중간 이미지를 등록하는 API 입니다.")
+    public ResponseEntity<?> setFirstImg(ProgressFirstImgRequestDTO imgRequestDTO) {
+        try {
+            progressManagementService.saveFirstImg(imgRequestDTO);
+            return response.success(imgRequestDTO.getEstimateId(), "해당 견적서와 매칭되는 형상관리에 첫 번째 사진 등록 완료", HttpStatus.OK);
+        } catch (IllegalArgumentException e) {
+            log.error(e.getMessage());
+            return response.fail("이미지 등록 실패", HttpStatus.INTERNAL_SERVER_ERROR);
+        } catch (Exception e) {
+            log.error(e.getMessage());
+            return response.fail("이미지 등록 실패", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
+    }
 
 }

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/controller/estimate/EstimateController.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/controller/estimate/EstimateController.java
@@ -6,6 +6,7 @@ import com.jjs.ClothingInventorySaleReformPlatform.dto.estimate.request.Estimate
 import com.jjs.ClothingInventorySaleReformPlatform.dto.estimate.response.EstimateResponseDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.dto.reformrequest.ReformRequestResponseDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.dto.response.Response;
+import com.jjs.ClothingInventorySaleReformPlatform.service.ProgressManagementService;
 import com.jjs.ClothingInventorySaleReformPlatform.service.estimate.EstimateService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -26,6 +27,7 @@ public class EstimateController {
 
     private final Response response;
     private final EstimateService estimateService;
+    private final ProgressManagementService progressManagementService;
 
     @GetMapping("/estimate/designer/requestForm")
     @Operation(summary = "디자이너 요청받은 의뢰 조회", description = "디자이너가 요청받은 모든 의뢰를 조회합니다.")
@@ -104,13 +106,14 @@ public class EstimateController {
     public ResponseEntity<?> selectEstimateStatus(@PathVariable Long estimateNumber, @PathVariable EstimateStatus status) {
         try {
             estimateService.selEstimateStatus(estimateNumber, status);
+            progressManagementService.setProgressStart(estimateNumber);
             return response.success(status, "견적서 상태 수정 완료", HttpStatus.OK);
         } catch (IllegalArgumentException e) {
             log.error(e.getMessage());
-            return response.fail("견적서 상태 수정 실패", HttpStatus.INTERNAL_SERVER_ERROR);
+            return response.fail("견적서 상태 수정 실패1", HttpStatus.INTERNAL_SERVER_ERROR);
         } catch (Exception e) {
             log.error(e.getMessage());
-            return response.fail("견적서 상태 수정 실패", HttpStatus.INTERNAL_SERVER_ERROR);
+            return response.fail("견적서 상태 수정 실패2", HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/controller/estimate/EstimateController.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/controller/estimate/EstimateController.java
@@ -106,7 +106,9 @@ public class EstimateController {
     public ResponseEntity<?> selectEstimateStatus(@PathVariable Long estimateNumber, @PathVariable EstimateStatus status) {
         try {
             estimateService.selEstimateStatus(estimateNumber, status);
-            progressManagementService.setProgressStart(estimateNumber);
+            if (status == EstimateStatus.REQUEST_ACCEPTED) {
+                progressManagementService.setProgressStart(estimateNumber);
+            }
             return response.success(status, "견적서 상태 수정 완료", HttpStatus.OK);
         } catch (IllegalArgumentException e) {
             log.error(e.getMessage());

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/reform/ProgressStatus.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/reform/ProgressStatus.java
@@ -1,0 +1,6 @@
+package com.jjs.ClothingInventorySaleReformPlatform.domain.reform;
+
+public enum ProgressStatus {
+
+    REFORM_START, REFORMING, REFORM_COMPLETE // 리폼 시작, 리폼 중, 리폼 완료
+}

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/reform/Progressmanagement.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/reform/Progressmanagement.java
@@ -1,0 +1,52 @@
+package com.jjs.ClothingInventorySaleReformPlatform.domain.reform;
+
+import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.estimate.Estimate;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.reformrequest.ReformRequest;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "ProgressManagement")
+public class Progressmanagement {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "PROGRESS_NUMBER", nullable = false)
+    private Long id;
+
+    @NotNull
+    @Column(length = 30)
+    private String clientEmail;  // 의뢰자 이메일
+
+    @NotNull
+    @Column(length = 30)
+    private String designerEmail;  // 디자이너 이메일
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "REQUEST_NUMBER", nullable = false)
+    private ReformRequest requestNumber;  // 의뢰 번호
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "ESTIMATE_NUMBER", nullable = false)
+    private Estimate estimateNumber;  // 견적서 번호
+
+    private String productImgUrl;  // 리폼 전 사진 - 상품 사진
+    private String firstImgUrl;  // 리폼 중 사진 1
+    private String secondImgUrl;  // 리폼 중 사진 2
+    private String completeImgUrl;  // 리폼 완료 사진
+
+    /**
+     * 구매자가 견적서 수락 시, REFORM_START 저장
+     * 디자이너가 firstImgUrl 등록 시, REFORMING으로 변경
+     * 디자이너가 completeImgUrl 등록 시, REFORM_COMPLETE으로 변경
+     */
+    @Enumerated(EnumType.STRING)
+    private ProgressStatus progressStatus;  // 리폼 상태
+}
+

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/reform/Progressmanagement.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/reform/Progressmanagement.java
@@ -47,6 +47,7 @@ public class Progressmanagement {
      * 디자이너가 completeImgUrl 등록 시, REFORM_COMPLETE으로 변경
      */
     @Enumerated(EnumType.STRING)
+    @Column(length = 20)
     private ProgressStatus progressStatus;  // 리폼 상태
 }
 

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/dto/reform/request/ProgressFirstImgRequestDTO.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/dto/reform/request/ProgressFirstImgRequestDTO.java
@@ -1,0 +1,13 @@
+package com.jjs.ClothingInventorySaleReformPlatform.dto.reform.request;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+public class ProgressFirstImgRequestDTO {
+
+    private Long estimateId;
+    private MultipartFile imgUrl;
+}

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/dto/reform/request/ProgressImgRequestDTO.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/dto/reform/request/ProgressImgRequestDTO.java
@@ -6,7 +6,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @Setter
-public class ProgressFirstImgRequestDTO {
+public class ProgressImgRequestDTO {
 
     private Long estimateId;
     private MultipartFile imgUrl;

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/repository/ProgressRepository.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/repository/ProgressRepository.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 public interface ProgressRepository extends JpaRepository<Progressmanagement, Long> {
 
     Optional<Progressmanagement> findByEstimateNumber_Id(Long estimateNumber);  // EstimateNumber 필드의 id 속성을 사용하여 ProgressManagement 엔티티를 조회
-    Optional<Progressmanagement> findByEstimateNumber(Estimate estimate);  // Estimate 엔티티의 인스턴스를 먼저 조회한 다음, 이 인스턴스를 사용하여 ProgressManagement를 조회
+    //Optional<Progressmanagement> findByEstimateNumber(Estimate estimate);  // Estimate 엔티티의 인스턴스를 먼저 조회한 다음, 이 인스턴스를 사용하여 ProgressManagement를 조회
 
 
 }

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/repository/ProgressRepository.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/repository/ProgressRepository.java
@@ -1,0 +1,15 @@
+package com.jjs.ClothingInventorySaleReformPlatform.repository;
+
+import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.Progressmanagement;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.estimate.Estimate;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ProgressRepository extends JpaRepository<Progressmanagement, Long> {
+
+    Optional<Progressmanagement> findByEstimateNumber_Id(Long estimateNumber);  // EstimateNumber 필드의 id 속성을 사용하여 ProgressManagement 엔티티를 조회
+    Optional<Progressmanagement> findByEstimateNumber(Estimate estimate);  // Estimate 엔티티의 인스턴스를 먼저 조회한 다음, 이 인스턴스를 사용하여 ProgressManagement를 조회
+
+
+}

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/repository/ProgressRepository.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/repository/ProgressRepository.java
@@ -2,6 +2,7 @@ package com.jjs.ClothingInventorySaleReformPlatform.repository;
 
 import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.Progressmanagement;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.estimate.Estimate;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/service/ProgressManagementService.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/service/ProgressManagementService.java
@@ -50,7 +50,7 @@ public class ProgressManagementService {
         } else {
             progressmanagement.setProgressStatus(ProgressStatus.REFORM_START);
             progressmanagement.setProductImgUrl(reformRequest.getProductNumber().getProductImg().get(0).getImgUrl());
-            progressmanagement.setClientEmail(estimate.getClientEmail().getEmail());
+            progressmanagement.setClientEmail(estimate.getPurchaserEmail().getEmail());
             progressmanagement.setDesignerEmail(estimate.getDesignerEmail().getEmail());
             progressmanagement.setRequestNumber(reformRequest);
             progressmanagement.setEstimateNumber(estimate);
@@ -75,6 +75,16 @@ public class ProgressManagementService {
                 .orElseThrow(() -> new IllegalArgumentException("해당되는 형상관리 정보가 없습니다."));
 
         progressmanagement.setSecondImgUrl(s3Service.uploadFile(imgRequestDTO.getImgUrl(), imageUploadPath));
+        progressRepository.save(progressmanagement);
+    }
+
+    @Transactional
+    public void saveCompleteImg(ProgressImgRequestDTO imgRequestDTO) throws IOException {
+        Progressmanagement progressmanagement = progressRepository.findByEstimateNumber_Id(imgRequestDTO.getEstimateId())
+                .orElseThrow(() -> new IllegalArgumentException("해당되는 형상관리 정보가 없습니다."));
+
+        progressmanagement.setCompleteImgUrl(s3Service.uploadFile(imgRequestDTO.getImgUrl(), imageUploadPath));
+        progressmanagement.setProgressStatus(ProgressStatus.REFORM_COMPLETE);
         progressRepository.save(progressmanagement);
     }
 }

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/service/ProgressManagementService.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/service/ProgressManagementService.java
@@ -1,0 +1,53 @@
+package com.jjs.ClothingInventorySaleReformPlatform.service;
+
+import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.ProgressStatus;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.Progressmanagement;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.estimate.Estimate;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.estimate.EstimateStatus;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.reformrequest.ReformRequest;
+import com.jjs.ClothingInventorySaleReformPlatform.repository.ProgressRepository;
+import com.jjs.ClothingInventorySaleReformPlatform.repository.estimate.EstimateRepository;
+import com.jjs.ClothingInventorySaleReformPlatform.repository.reformrequest.ReformRequestRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ProgressManagementService {
+
+    private final EstimateRepository estimateRepository;
+    private final ProgressRepository progressRepository;
+    private final ReformRequestRepository requestRepository;
+
+
+    /**
+     * 구매자의 견적서 수락 시, 형상관리 시작
+     * @param estimateNumber
+     */
+    @Transactional
+    public void setProgressStart(Long estimateNumber) {
+        Estimate estimate = estimateRepository.findEstimateById(estimateNumber)
+                .orElseThrow(() -> new IllegalArgumentException("견적서가 존재하지 않습니다1."));
+
+        Progressmanagement progressmanagement = new Progressmanagement();
+
+        ReformRequest reformRequest = requestRepository.findReformRequestById(estimate.getRequestNumber().getId())
+                .orElseThrow(() -> new IllegalArgumentException("요청서가 존재하지 않습니다."));
+
+        if (estimate.getEstimateStatus() != EstimateStatus.REQUEST_ACCEPTED) {
+            throw new RuntimeException("수락된 의뢰만 형상관리 진행이 가능합니다.");
+        } else {
+            progressmanagement.setProgressStatus(ProgressStatus.REFORM_START);
+            progressmanagement.setFirstImgUrl(reformRequest.getProductNumber().getProductImg().get(0).getImgUrl());
+            progressmanagement.setClientEmail(estimate.getClientEmail().getEmail());
+            progressmanagement.setDesignerEmail(estimate.getDesignerEmail().getEmail());
+            progressmanagement.setRequestNumber(reformRequest);
+            progressmanagement.setEstimateNumber(estimate);
+            progressRepository.save(progressmanagement);
+            System.out.println("44444");
+        }
+    }
+}

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/service/ProgressManagementService.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/service/ProgressManagementService.java
@@ -5,7 +5,7 @@ import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.Progressmanagem
 import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.estimate.Estimate;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.estimate.EstimateStatus;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.reformrequest.ReformRequest;
-import com.jjs.ClothingInventorySaleReformPlatform.dto.reform.request.ProgressFirstImgRequestDTO;
+import com.jjs.ClothingInventorySaleReformPlatform.dto.reform.request.ProgressImgRequestDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.repository.ProgressRepository;
 import com.jjs.ClothingInventorySaleReformPlatform.repository.estimate.EstimateRepository;
 import com.jjs.ClothingInventorySaleReformPlatform.repository.reformrequest.ReformRequestRepository;
@@ -27,6 +27,8 @@ public class ProgressManagementService {
     private final EstimateRepository estimateRepository;
     private final ProgressRepository progressRepository;
     private final ReformRequestRepository requestRepository;
+
+    private String imageUploadPath = "ProgressManagement/";
 
 
     /**
@@ -58,12 +60,21 @@ public class ProgressManagementService {
     }
 
     @Transactional
-    public void saveFirstImg(ProgressFirstImgRequestDTO imgRequestDTO) throws IOException {
+    public void saveFirstImg(ProgressImgRequestDTO imgRequestDTO) throws IOException {
         Progressmanagement progressmanagement = progressRepository.findByEstimateNumber_Id(imgRequestDTO.getEstimateId())
                 .orElseThrow(() -> new IllegalArgumentException("해당되는 형상관리 정보가 없습니다."));
 
-        progressmanagement.setFirstImgUrl(s3Service.uploadFile(imgRequestDTO.getImgUrl(), "ProgressManagement/"));
+        progressmanagement.setFirstImgUrl(s3Service.uploadFile(imgRequestDTO.getImgUrl(), imageUploadPath));
         progressmanagement.setProgressStatus(ProgressStatus.REFORMING);
+        progressRepository.save(progressmanagement);
+    }
+
+    @Transactional
+    public void saveSecondImg(ProgressImgRequestDTO imgRequestDTO) throws IOException {
+        Progressmanagement progressmanagement = progressRepository.findByEstimateNumber_Id(imgRequestDTO.getEstimateId())
+                .orElseThrow(() -> new IllegalArgumentException("해당되는 형상관리 정보가 없습니다."));
+
+        progressmanagement.setSecondImgUrl(s3Service.uploadFile(imgRequestDTO.getImgUrl(), imageUploadPath));
         progressRepository.save(progressmanagement);
     }
 }

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/service/estimate/EstimateService.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/service/estimate/EstimateService.java
@@ -2,6 +2,8 @@ package com.jjs.ClothingInventorySaleReformPlatform.service.estimate;
 
 
 import com.jjs.ClothingInventorySaleReformPlatform.controller.product.AuthenticationFacade;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.ProgressStatus;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.Progressmanagement;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.estimate.Estimate;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.estimate.EstimateImage;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.estimate.EstimateStatus;
@@ -11,6 +13,7 @@ import com.jjs.ClothingInventorySaleReformPlatform.domain.user.DesignerInfo;
 import com.jjs.ClothingInventorySaleReformPlatform.dto.estimate.request.EstimateRequestDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.dto.estimate.response.EstimateResponseDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.dto.reformrequest.ReformRequestResponseDTO;
+import com.jjs.ClothingInventorySaleReformPlatform.repository.ProgressRepository;
 import com.jjs.ClothingInventorySaleReformPlatform.repository.estimate.EstimateImgRepository;
 import com.jjs.ClothingInventorySaleReformPlatform.repository.estimate.EstimateRepository;
 import com.jjs.ClothingInventorySaleReformPlatform.repository.reformrequest.ReformRequestRepository;
@@ -35,6 +38,7 @@ public class EstimateService {
     private final EstimateRepository estimateRepository;
     private final EstimateImgRepository estimateImgRepository;
     private final ReformRequestRepository requestRepository;
+    private final ProgressRepository progressRepository;
 
     /**
      * 로그인한 디자이너의 요청받은 모든 의뢰 리스트를 불러오는 메소드
@@ -215,5 +219,7 @@ public class EstimateService {
             estimateRepository.save(estimate);
         }
     }
+
+
 }
 


### PR DESCRIPTION
# 🚀 개요
디자이너는 구매자가 리폼 현황을 알 수 있도록 리폼 과정을 사진으로 보여준다.

## 🔍 변경사항
- 형상관리 시 4개의 이미지가 순차적으로 등록되는 ProcessManagement 테이블(엔티티)가 생성됨
- `Progressmanagement`(엔티티)에서 `progressStatus`(Enum 타입)의 데이터 타입의 길이가 처음에 저장되는 값인 `REFORM_START`가 저장되어 해당 문자열의 최대 길이가 고정된다. 이로 인해 리폼 완료된 사진 등록 API 사용 시, 상태 변경 부분에 `REFORM_COMPLETE`가 저장되면서 `org.springframework.orm.jpa.JpaSystemException: could not execute statement`에러가 발생하였다. -> `@Column(length = 20)`를 추가하여 초반에 데이터 타입을 `varchar(20)`으로 설정했다.

## ⏳ 작업 내용
- [x] 구매자가 견적서 수락 시, 현상관리 테이블에 리폼 전 사진인 상품 사진이 저장되도록 API 수정(상태 : 리폼 시작)
- [x] 리폼 중인 사진 1 등록 API 추가(상태: 리폼 중)
- [x] 리폼 중인 사진 2 등록 API 추가
- [x] 리폼 완료된 사진 등록 API 추가(상태: 리폼 완료)

### 📝 논의사항

