### PR TITLE
🚀 feature 구매자가 리폼 수락 시 진행되는 주문 관련 API

### DIFF
--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/controller/reform/estimate/EstimateController.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/controller/reform/estimate/EstimateController.java
@@ -101,15 +101,12 @@ public class EstimateController {
         }
     }
 
-    @PatchMapping(value = "/estimate/purchaser/{estimateNumber}/{status}")
-    @Operation(summary = "구매자의 견적서 수락 및 거절", description = "구매자는 견적서를 확인하고 수락 및 거절한다.")
-    public ResponseEntity<?> selectEstimateStatus(@PathVariable Long estimateNumber, @PathVariable EstimateStatus status) {
+    @PostMapping(value = "/estimate/purchaser/{estimateNumber}/accept")
+    @Operation(summary = "구매자의 견적서 수락 시작", description = "구매자는 견적서를 확인하고 수락하고 다음 배송정보 입력 창으로 넘어간다.")
+    public ResponseEntity<?> selectEstimateStatus(@PathVariable Long estimateNumber) {
         try {
-            estimateService.selEstimateStatus(estimateNumber, status);
-            if (status == EstimateStatus.REQUEST_ACCEPTED) {
-                progressManagementService.setProgressStart(estimateNumber);
-            }
-            return response.success(status, "견적서 상태 수정 완료", HttpStatus.OK);
+            estimateService.selEstimateAccept(estimateNumber);  // 수락 누르면 리품 주문 테이블 생성되고 상태가 주문중이 들어감
+            return response.success("견적서 수락 및 주문 중 : 1", HttpStatus.OK);
         } catch (IllegalArgumentException e) {
             log.error(e.getMessage());
             return response.fail("견적서 상태 수정 실패1", HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/controller/reform/estimate/EstimateController.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/controller/reform/estimate/EstimateController.java
@@ -5,6 +5,7 @@ import com.jjs.ClothingInventorySaleReformPlatform.dto.reform.estimate.ClientRes
 import com.jjs.ClothingInventorySaleReformPlatform.dto.reform.estimate.request.EstimateRequestDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.dto.reform.estimate.request.ReformOrderRequestDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.dto.reform.estimate.response.EstimateResponseDTO;
+import com.jjs.ClothingInventorySaleReformPlatform.dto.reform.estimate.response.ReformOrderResponseDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.dto.reform.reformrequest.ReformRequestResponseDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.dto.response.Response;
 import com.jjs.ClothingInventorySaleReformPlatform.service.reform.progressmanagement.ProgressManagementService;
@@ -110,10 +111,10 @@ public class EstimateController {
             return response.success("견적서 수락 및 주문 중 : 1", HttpStatus.OK);
         } catch (IllegalArgumentException e) {
             log.error(e.getMessage());
-            return response.fail("견적서 상태 수정 실패1", HttpStatus.INTERNAL_SERVER_ERROR);
+            return response.fail("견적서 수락 실패1", HttpStatus.INTERNAL_SERVER_ERROR);
         } catch (Exception e) {
             log.error(e.getMessage());
-            return response.fail("견적서 상태 수정 실패2", HttpStatus.INTERNAL_SERVER_ERROR);
+            return response.fail("견적서 수락 실패2", HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -125,10 +126,10 @@ public class EstimateController {
             return response.success("견적서 거절 완료", HttpStatus.OK);
         } catch (IllegalArgumentException e) {
             log.error(e.getMessage());
-            return response.fail("견적서 상태 수정 실패1", HttpStatus.INTERNAL_SERVER_ERROR);
+            return response.fail("견적서 거절 실패1", HttpStatus.INTERNAL_SERVER_ERROR);
         } catch (Exception e) {
             log.error(e.getMessage());
-            return response.fail("견적서 상태 수정 실패2", HttpStatus.INTERNAL_SERVER_ERROR);
+            return response.fail("견적서 거절 실패2", HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -140,10 +141,25 @@ public class EstimateController {
             return response.success("정보 입력 완료", HttpStatus.OK);
         } catch (IllegalArgumentException e) {
             log.error(e.getMessage());
-            return response.fail("견적서 상태 수정 실패1", HttpStatus.INTERNAL_SERVER_ERROR);
+            return response.fail("정보 입력 실패1", HttpStatus.INTERNAL_SERVER_ERROR);
         } catch (Exception e) {
             log.error(e.getMessage());
-            return response.fail("견적서 상태 수정 실패2", HttpStatus.INTERNAL_SERVER_ERROR);
+            return response.fail("정보 입력 실패2", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @GetMapping(value = "/estimate/purchaser/acceptReformOrder/{estimateNumber}")
+    @Operation(summary = "구매자가 리폼 주문 비용(리폼 비용, 상품 가격, 총 가격) 조회", description = "구매자가 견적서의 개인 정보 입력 후 다음 페이지에서 총 리폼 주문 비용을 확인한다.")
+    public ResponseEntity<?> getEstimatePrice(@PathVariable Long estimateNumber) {
+        try {
+            ReformOrderResponseDTO reformOrderResponseDTO = estimateService.getAcceptOrderingPrice(estimateNumber);
+            return response.success(reformOrderResponseDTO, "리폼 비용 조회 성공", HttpStatus.OK);
+        } catch (IllegalArgumentException e) {
+            log.error(e.getMessage());
+            return response.fail("리폼 비용 조회 실패1", HttpStatus.INTERNAL_SERVER_ERROR);
+        } catch (Exception e) {
+            log.error(e.getMessage());
+            return response.fail("리폼 비용 조회 실패2", HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/controller/reform/estimate/EstimateController.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/controller/reform/estimate/EstimateController.java
@@ -103,10 +103,25 @@ public class EstimateController {
 
     @PostMapping(value = "/estimate/purchaser/{estimateNumber}/accept")
     @Operation(summary = "구매자의 견적서 수락 시작", description = "구매자는 견적서를 확인하고 수락하고 다음 배송정보 입력 창으로 넘어간다.")
-    public ResponseEntity<?> selectEstimateStatus(@PathVariable Long estimateNumber) {
+    public ResponseEntity<?> selectEstimateAccept(@PathVariable Long estimateNumber) {
         try {
             estimateService.selEstimateAccept(estimateNumber);  // 수락 누르면 리품 주문 테이블 생성되고 상태가 주문중이 들어감
             return response.success("견적서 수락 및 주문 중 : 1", HttpStatus.OK);
+        } catch (IllegalArgumentException e) {
+            log.error(e.getMessage());
+            return response.fail("견적서 상태 수정 실패1", HttpStatus.INTERNAL_SERVER_ERROR);
+        } catch (Exception e) {
+            log.error(e.getMessage());
+            return response.fail("견적서 상태 수정 실패2", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @PatchMapping(value = "/estimate/purchaser/{estimateNumber}/reject")
+    @Operation(summary = "구매자의 견적서 거절 완료", description = "구매자는 견적서를 확인하고 원치 않은 경우 거절한다.")
+    public ResponseEntity<?> selectEstimateReject(@PathVariable Long estimateNumber) {
+        try {
+            estimateService.selEstimateReject(estimateNumber);  // 거절 버튼을 누르면 견적서 상태가 거절됨이 됨
+            return response.success("견적서 거절 완료", HttpStatus.OK);
         } catch (IllegalArgumentException e) {
             log.error(e.getMessage());
             return response.fail("견적서 상태 수정 실패1", HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/controller/reform/estimate/EstimateController.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/controller/reform/estimate/EstimateController.java
@@ -3,6 +3,7 @@ package com.jjs.ClothingInventorySaleReformPlatform.controller.reform.estimate;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.estimate.EstimateStatus;
 import com.jjs.ClothingInventorySaleReformPlatform.dto.reform.estimate.ClientResponse;
 import com.jjs.ClothingInventorySaleReformPlatform.dto.reform.estimate.request.EstimateRequestDTO;
+import com.jjs.ClothingInventorySaleReformPlatform.dto.reform.estimate.request.ReformOrderRequestDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.dto.reform.estimate.response.EstimateResponseDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.dto.reform.reformrequest.ReformRequestResponseDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.dto.response.Response;
@@ -122,6 +123,21 @@ public class EstimateController {
         try {
             estimateService.selEstimateReject(estimateNumber);  // 거절 버튼을 누르면 견적서 상태가 거절됨이 됨
             return response.success("견적서 거절 완료", HttpStatus.OK);
+        } catch (IllegalArgumentException e) {
+            log.error(e.getMessage());
+            return response.fail("견적서 상태 수정 실패1", HttpStatus.INTERNAL_SERVER_ERROR);
+        } catch (Exception e) {
+            log.error(e.getMessage());
+            return response.fail("견적서 상태 수정 실패2", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @PatchMapping(value = "/estimate/purchaser/acceptReformOrder/{estimateNumber}")
+    @Operation(summary = "구매자의 견적서 수락 후 개인정보 입력", description = "구매자가 견적서 수락했을 때, 구매자는 배송 정보 및 개인 정보를 입력한다.")
+    public ResponseEntity<?> estimateAcceptOrdering(@RequestBody ReformOrderRequestDTO reformOrderRequestDTO, @PathVariable Long estimateNumber) {
+        try {
+            estimateService.acceptOrdering(reformOrderRequestDTO, estimateNumber);
+            return response.success("정보 입력 완료", HttpStatus.OK);
         } catch (IllegalArgumentException e) {
             log.error(e.getMessage());
             return response.fail("견적서 상태 수정 실패1", HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/controller/reform/estimate/EstimateController.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/controller/reform/estimate/EstimateController.java
@@ -163,5 +163,30 @@ public class EstimateController {
         }
     }
 
+    /**
+     * 실행 전 -> estimate:REQUEST_WAITING, reformorders:ORDERING, progress_management:현재 생성X
+     * 실행 후 -> estimate:REQUEST_ACCEPTED, reformorders:ORDER_COMPLETE, progress_management:REFORM_START
+     * @param estimateNumber
+     * @return
+     */
+    @PatchMapping(value = "/estimate/purchaser/acceptReformOrder/{estimateNumber}/complete")
+    @Operation(summary = "견적서에 대한 리폼 및 상품을 최종적으로 결제 및 수락", description = "구매자는 리폼 주문 비용 확인 후 결제 및 수락 버튼(해당 API)으로 해당 견적서를 최종적으로 수락한다. 수락 시 형상관리 테이블에 초기 이미지가 저장된다.")
+    public ResponseEntity<?> setEstimateAccept(@PathVariable Long estimateNumber) {
+        try {
+            estimateService.setAcceptComplete(estimateNumber);
+            return response.success("리폼 결제 및 수락 완료", HttpStatus.OK);
+        } catch (IllegalArgumentException e) {
+            log.error(e.getMessage());
+            return response.fail("리폼 결제 및 수락 실패1 (견적서 조회)", HttpStatus.INTERNAL_SERVER_ERROR);
+        } catch (RuntimeException e) {
+            log.error(e.getMessage());
+            return response.fail("리폼 결제 및 수락 실패2 (수락된 의뢰가 아님)", HttpStatus.INTERNAL_SERVER_ERROR);
+        } catch (Exception e) {
+            log.error(e.getMessage());
+            return response.fail("리폼 결제 및 수락 실패3", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+
 }
 

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/reform/estimate/Estimate.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/reform/estimate/Estimate.java
@@ -31,7 +31,10 @@ public class Estimate {  // 견적서
     private List<EstimateImage> estimateImg = new ArrayList<>();
 
     @Column(name = "PRICE", nullable = false)
-    private String price;  // 가격
+    private String price;  // 총 가격
+
+    @Column(name = "REFORM_PRICE", nullable = false)
+    private String reformPrice;  // 리폼 비용
 
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/reform/estimate/Estimate.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/reform/estimate/Estimate.java
@@ -1,5 +1,6 @@
 package com.jjs.ClothingInventorySaleReformPlatform.domain.reform.estimate;
 
+import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.order.ReformOrder;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.reformrequest.ReformRequest;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.user.DesignerInfo;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.user.PurchaserInfo;
@@ -31,10 +32,10 @@ public class Estimate {  // 견적서
     private List<EstimateImage> estimateImg = new ArrayList<>();
 
     @Column(name = "PRICE", nullable = false)
-    private String price;  // 총 가격
+    private int price;  // 총 가격
 
     @Column(name = "REFORM_PRICE", nullable = false)
-    private String reformPrice;  // 리폼 비용
+    private int reformPrice;  // 리폼 비용
 
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
@@ -50,6 +51,11 @@ public class Estimate {  // 견적서
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "REQUEST_NUMBER", nullable = false)
     private ReformRequest requestNumber;  // 의뢰 번호
+
+
+    @OneToOne(mappedBy = "estimate", fetch = FetchType.LAZY)
+    private ReformOrder reformOrder;
+
 
     @Enumerated(EnumType.STRING)
     private EstimateStatus estimateStatus;  // 견적서 상태 REQUEST_WAITING, REQUEST_REJECTED, REQUEST_ACCEPTED

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/reform/order/ReformOrder.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/reform/order/ReformOrder.java
@@ -21,7 +21,8 @@ public class ReformOrder {
     @Column(name = "order_id")
     private Long orderId;  // 주문 번호
 
-    @OneToOne(mappedBy = "ESTIMATE_NUMBER", fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "ESTIMATE_NUMBER", nullable = false)
     private Estimate estimate;
 
     @CreatedDate

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/reform/order/ReformOrder.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/reform/order/ReformOrder.java
@@ -1,0 +1,40 @@
+package com.jjs.ClothingInventorySaleReformPlatform.domain.reform.order;
+
+import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.estimate.Estimate;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@Entity
+@Getter
+@Table(name = "REFORMORDERS")
+@Setter
+public class ReformOrder {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "order_id")
+    private Long orderId;  // 주문 번호
+
+    @OneToOne(mappedBy = "ESTIMATE_NUMBER", fetch = FetchType.LAZY)
+    private Estimate estimate;
+
+    @CreatedDate
+    private LocalDateTime orderDate;  // 주문일
+    private String postcode;  // 우편번호
+    private String address;  // 주소
+    private String detailAddress;  // 상세주소
+    private String phoneNumber;  // 휴대폰 번호
+    private String deliveryRequest;  // 배송 요청사항
+    private int totalPrice;  // 총 주문 금액
+
+    @Enumerated(EnumType.STRING)
+    private ReformOrderStatus orderStatus;  // 주문 상태
+
+
+}

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/reform/order/ReformOrderStatus.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/reform/order/ReformOrderStatus.java
@@ -1,0 +1,5 @@
+package com.jjs.ClothingInventorySaleReformPlatform.domain.reform.order;
+
+public enum ReformOrderStatus {
+    ORDER_COMPLETE, ORDERING // 주문 완료, 주문 중
+}

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/dto/reform/estimate/request/EstimateRequestDTO.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/dto/reform/estimate/request/EstimateRequestDTO.java
@@ -10,10 +10,10 @@ import java.util.List;
 @Setter
 public class EstimateRequestDTO {
 
-    private String estimateInfo;  // 의뢰 정보(내용)
+    private String estimateInfo;  // 견적서 정보(내용)
 
-    private List<MultipartFile> estimateImg;  // 의뢰 사진
+    private List<MultipartFile> estimateImg;  // 견적서 사진
 
-    private String price; // 희망 가격
+    private String reformPrice; // 희망 가격
 
 }

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/dto/reform/estimate/request/EstimateRequestDTO.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/dto/reform/estimate/request/EstimateRequestDTO.java
@@ -14,6 +14,6 @@ public class EstimateRequestDTO {
 
     private List<MultipartFile> estimateImg;  // 견적서 사진
 
-    private String reformPrice; // 희망 가격
+    private int reformPrice; // 희망 가격
 
 }

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/dto/reform/estimate/request/ReformOrderRequestDTO.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/dto/reform/estimate/request/ReformOrderRequestDTO.java
@@ -1,0 +1,15 @@
+package com.jjs.ClothingInventorySaleReformPlatform.dto.reform.estimate.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ReformOrderRequestDTO {
+
+    private String postcode;
+    private String address;
+    private String detailAddress;
+    private String phoneNumber;
+    private String deliveryRequest;
+}

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/dto/reform/estimate/response/EstimateResponseDTO.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/dto/reform/estimate/response/EstimateResponseDTO.java
@@ -11,7 +11,8 @@ public class EstimateResponseDTO {
     private String clientEmail;  // 의뢰자 이메일
     private String designerEmail;  // 디자이너 이메일
     private String estimateInfo;  // 의뢰 정보(내용)
-    private String price; // 희망 가격
+    private String price; // 리폼 가격
+    private String totalPrice;  // 리폼 + 상품 가격
     private String estimateImg;  // 의뢰 사진
     private Long requestNumber;  // 의뢰서 번호
 

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/dto/reform/estimate/response/EstimateResponseDTO.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/dto/reform/estimate/response/EstimateResponseDTO.java
@@ -11,8 +11,8 @@ public class EstimateResponseDTO {
     private String clientEmail;  // 의뢰자 이메일
     private String designerEmail;  // 디자이너 이메일
     private String estimateInfo;  // 의뢰 정보(내용)
-    private String price; // 리폼 가격
-    private String totalPrice;  // 리폼 + 상품 가격
+    private int price; // 리폼 가격
+    private int totalPrice;  // 리폼 + 상품 가격
     private String estimateImg;  // 의뢰 사진
     private Long requestNumber;  // 의뢰서 번호
 

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/dto/reform/estimate/response/ReformOrderResponseDTO.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/dto/reform/estimate/response/ReformOrderResponseDTO.java
@@ -1,0 +1,13 @@
+package com.jjs.ClothingInventorySaleReformPlatform.dto.reform.estimate.response;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ReformOrderResponseDTO {
+
+    private int productPrice;
+    private int reformPrice;
+    private int totalPrice;
+}

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/repository/reform/order/ReformOrderRepository.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/repository/reform/order/ReformOrderRepository.java
@@ -1,0 +1,7 @@
+package com.jjs.ClothingInventorySaleReformPlatform.repository.reform.order;
+
+import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.order.ReformOrder;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReformOrderRepository extends JpaRepository<ReformOrder, Long> {
+}

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/repository/reform/order/ReformOrderRepository.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/repository/reform/order/ReformOrderRepository.java
@@ -1,7 +1,12 @@
 package com.jjs.ClothingInventorySaleReformPlatform.repository.reform.order;
 
+import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.estimate.Estimate;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.order.ReformOrder;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ReformOrderRepository extends JpaRepository<ReformOrder, Long> {
+
+    Optional<ReformOrder> findReformOrderByEstimateId(Long id);
 }

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/service/reform/estimate/EstimateService.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/service/reform/estimate/EstimateService.java
@@ -10,7 +10,9 @@ import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.order.ReformOrd
 import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.reformrequest.ReformRequest;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.reformrequest.ReformRequestStatus;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.user.DesignerInfo;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.user.PurchaserInfo;
 import com.jjs.ClothingInventorySaleReformPlatform.dto.reform.estimate.request.EstimateRequestDTO;
+import com.jjs.ClothingInventorySaleReformPlatform.dto.reform.estimate.request.ReformOrderRequestDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.dto.reform.estimate.response.EstimateResponseDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.dto.reform.reformrequest.ReformRequestResponseDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.repository.reform.order.ReformOrderRepository;
@@ -21,6 +23,8 @@ import com.jjs.ClothingInventorySaleReformPlatform.repository.reform.reformreque
 import com.jjs.ClothingInventorySaleReformPlatform.service.s3.S3Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -239,6 +243,22 @@ public class EstimateService {
             estimate.setEstimateStatus(EstimateStatus.REQUEST_REJECTED);
             estimateRepository.save(estimate);
         }
+    }
+
+    @Transactional
+    public void acceptOrdering(ReformOrderRequestDTO reformOrderRequestDTO, Long estimateNumber) {
+
+        ReformOrder reformOrder = reformOrderRepository.findReformOrderByEstimateId(estimateNumber)
+                .orElseThrow(() -> new IllegalArgumentException("견적서가 존재하지 않습니다."));
+
+        reformOrder.setPhoneNumber(reformOrderRequestDTO.getPhoneNumber());
+        reformOrder.setDeliveryRequest(reformOrderRequestDTO.getDeliveryRequest());
+        reformOrder.setPostcode(reformOrderRequestDTO.getPostcode());
+        reformOrder.setAddress(reformOrderRequestDTO.getAddress());
+        reformOrder.setDetailAddress(reformOrderRequestDTO.getDetailAddress());
+
+        reformOrderRepository.save(reformOrder);
+
     }
 
 

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/service/reform/estimate/EstimateService.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/service/reform/estimate/EstimateService.java
@@ -131,8 +131,8 @@ public class EstimateService {
         estimate.setEstimateInfo(estimateRequestDTO.getEstimateInfo());
         estimate.setReformPrice(estimateRequestDTO.getReformPrice());  // 리폼 비용
 
-        int totalPrice = Integer.parseInt(reformRequest.getProductNumber().getPrice() + estimateRequestDTO.getReformPrice());
-        estimate.setPrice(String.valueOf(totalPrice));
+        int totalPrice = (reformRequest.getProductNumber().getPrice() + estimateRequestDTO.getReformPrice());
+        estimate.setPrice(totalPrice);
         estimateRepository.save(estimate);
 
         saveImageList(estimateRequestDTO, estimate);
@@ -222,8 +222,22 @@ public class EstimateService {
         } else {
             ReformOrder reformOrder = new ReformOrder();
             reformOrder.setOrderStatus(ReformOrderStatus.ORDERING);  // 주문 상태 : 주문 중
-            reformOrder.setTotalPrice(Integer.parseInt(estimate.getPrice()));  // 상품 총 가격
+            reformOrder.setTotalPrice(estimate.getPrice());  // 상품 총 가격
+            reformOrder.setEstimate(estimate);
             reformOrderRepository.save(reformOrder);
+        }
+    }
+
+    @Transactional
+    public void selEstimateReject(Long estimateNumber) {
+        Estimate estimate = estimateRepository.findEstimateById(estimateNumber)
+                .orElseThrow(() -> new IllegalArgumentException("견적서가 존재하지 않습니다."));
+
+        if (estimate.getEstimateStatus() != EstimateStatus.REQUEST_WAITING) {
+            throw new RuntimeException("이미 진행 중인 의뢰로 수정이 불가합니다.");
+        } else {
+            estimate.setEstimateStatus(EstimateStatus.REQUEST_REJECTED);
+            estimateRepository.save(estimate);
         }
     }
 

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/service/reform/estimate/EstimateService.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/service/reform/estimate/EstimateService.java
@@ -14,6 +14,7 @@ import com.jjs.ClothingInventorySaleReformPlatform.domain.user.PurchaserInfo;
 import com.jjs.ClothingInventorySaleReformPlatform.dto.reform.estimate.request.EstimateRequestDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.dto.reform.estimate.request.ReformOrderRequestDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.dto.reform.estimate.response.EstimateResponseDTO;
+import com.jjs.ClothingInventorySaleReformPlatform.dto.reform.estimate.response.ReformOrderResponseDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.dto.reform.reformrequest.ReformRequestResponseDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.repository.reform.order.ReformOrderRepository;
 import com.jjs.ClothingInventorySaleReformPlatform.repository.reform.progressmanagement.ProgressRepository;
@@ -261,6 +262,18 @@ public class EstimateService {
 
     }
 
+    @Transactional
+    public ReformOrderResponseDTO getAcceptOrderingPrice(Long estimateNumber) {
 
+        Estimate estimate = estimateRepository.findEstimateById(estimateNumber)
+                .orElseThrow(() -> new IllegalArgumentException("견적서가 존재하지 않습니다."));
+
+        ReformOrderResponseDTO reformOrderResponseDTO = new ReformOrderResponseDTO();
+        reformOrderResponseDTO.setProductPrice(estimate.getRequestNumber().getProductNumber().getPrice());  // 상품 가격
+        reformOrderResponseDTO.setReformPrice(estimate.getReformPrice());  // 리폼 가격
+        reformOrderResponseDTO.setTotalPrice(estimate.getReformPrice());  // 총 가격
+
+        return reformOrderResponseDTO;
+    }
 }
 

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/service/reform/progressmanagement/ProgressManagementService.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/service/reform/progressmanagement/ProgressManagementService.java
@@ -32,34 +32,6 @@ public class ProgressManagementService {
     private String imageUploadPath = "ProgressManagement/";
 
 
-    /**
-     * 구매자의 견적서 수락 시, 형상관리 시작
-     * @param estimateNumber
-     */
-    @Transactional
-    public void setProgressStart(Long estimateNumber) {
-        Estimate estimate = estimateRepository.findEstimateById(estimateNumber)
-                .orElseThrow(() -> new IllegalArgumentException("견적서가 존재하지 않습니다1."));
-
-        Progressmanagement progressmanagement = new Progressmanagement();
-
-        ReformRequest reformRequest = requestRepository.findReformRequestById(estimate.getRequestNumber().getId())
-                .orElseThrow(() -> new IllegalArgumentException("요청서가 존재하지 않습니다."));
-
-        if (estimate.getEstimateStatus() != EstimateStatus.REQUEST_ACCEPTED) {
-            throw new RuntimeException("수락된 의뢰만 형상관리 진행이 가능합니다.");
-        } else {
-            progressmanagement.setProgressStatus(ProgressStatus.REFORM_START);
-            progressmanagement.setProductImgUrl(reformRequest.getProductNumber().getProductImg().get(0).getImgUrl());
-            progressmanagement.setClientEmail(estimate.getPurchaserEmail().getEmail());
-            progressmanagement.setDesignerEmail(estimate.getDesignerEmail().getEmail());
-            progressmanagement.setRequestNumber(reformRequest);
-            progressmanagement.setEstimateNumber(estimate);
-            progressRepository.save(progressmanagement);
-            System.out.println("44444");
-        }
-    }
-
     @Transactional
     public void saveFirstImg(ProgressImgRequestDTO imgRequestDTO) throws IOException {
         Progressmanagement progressmanagement = progressRepository.findByEstimateNumber_Id(imgRequestDTO.getEstimateId())


### PR DESCRIPTION
# 🚀 개요
구매자가 리폼 견적서 수락 시 기존 상품에 리폼 비용을 추가한 총 비용이 나와야하며 개인정보(배송 정보, 개인 정보) 입력 후 리폼 수락이 완료된다.

과정 : 구매자 마이페이지(견적서 수락 버튼) -> 개인 정보 입력 창(다음으로 버튼) -> 총 비용이 표시되는 창(결제 및 수락 버튼) -> 수락 완료 후 다시 마이페이지로 이동

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->


## ⏳ 작업 내용
- [x] 견적서 수락 버튼이 눌리면 해당 견적서에 대한 리폼 주문이 생성되는 API(리폼 주문 상태:`ORDERING`)
- [x] 견적서 거절 버튼이 눌리면 해당 견적서의 상태가 `REQUEST_REJECTED`로 변경되는 API
- [x] 입력받은 구매자 개인 정보를 ReformOrder 엔티티에 저장하는 API
- [x] 견적서 id로 총 가격 조회하는 API (총 비용, 리폼 비용, 상품 가격)
- [x] 견적서에 대한 리폼 및 상품을 결제 및 수락하는 API (
    *실행 전 -> estimate:`REQUEST_WAITING`, reformorders:`ORDERING`, progress_management:`현재 생성X`*
    *실행 후 -> estimate:`REQUEST_ACCEPTED`, reformorders:`ORDER_COMPLETE`, progress_management:`REFORM_START`* )

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
