### PR TITLE
[Refactor/67] 상품 삭제 로직 변경 : 물리적 삭제 → 논리적 삭제(상품이 db에서 제거되지 않고 조회만 안됨)

### DIFF
--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/cart/repository/CartProductRepository.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/cart/repository/CartProductRepository.java
@@ -12,4 +12,7 @@ public interface CartProductRepository extends JpaRepository<CartProduct, Long> 
     List<CartProduct> findByCartId(Long cartId);
     Optional<CartProduct> deleteByCartIdAndProductId(long cartId, long productId);
 
+    // 삭제된 상품은 조회되지 않음
+    List<CartProduct> findByCartIdAndProductIsDeletedFalse(Long cartId);
+
 }

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/cart/service/CartService.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/cart/service/CartService.java
@@ -69,7 +69,7 @@ public class CartService {
 
     // 장바구니에 상품 조회
     public List<ProductInfoDTO> userCartView(Cart cart) {
-        List<CartProduct> cartProducts = cartProductRepository.findByCartId(cart.getId());
+        List<CartProduct> cartProducts = cartProductRepository.findByCartIdAndProductIsDeletedFalse(cart.getId());
         return cartProducts.stream()
                 .map(ProductInfoDTO::from)
                 .collect(Collectors.toList());

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/product/controller/ProductController.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/product/controller/ProductController.java
@@ -83,8 +83,8 @@ public class ProductController {
     }
 
     // 상품 삭제
-    @Operation(summary = "상품 삭제", description = "로그인한 판매자는 본인이 등록한 상품을 삭제한다.")
-    @DeleteMapping("/product/seller/register/{productId}")  // (DELETE)http://localhost:8080/item/delete/1
+    @Operation(summary = "상품 삭제", description = "로그인한 판매자는 본인이 등록한 상품을 논리적으로 삭제한다.(db에는 상품이 존재하지만 보이지 않도록 수정한다.)")
+    @PatchMapping("/product/seller/register/{productId}")
     public ResponseEntity<?> deleteProduct(@PathVariable Long productId) {
         try {
             productService.deleteProduct(productId);

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/product/entity/Product.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/product/entity/Product.java
@@ -36,6 +36,10 @@ public class Product extends BaseEntity {  // BaseEntity가 등록시간, 수정
     @Enumerated(EnumType.STRING)
     private ProductSellStatus productSellStatus; // 상품 상태 (품절 or 판매 가능)[SELL, SOLD_OUT]
 
+    // 논리적 삭제를 위한 필드
+    @Column
+    private boolean isDeleted = false;
+
     // 상품 삭제 시 이미지 DB 도 같이 삭제 , cascade 옵션
     @OneToMany(mappedBy = "product", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
     @OrderBy("id asc")

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/product/entity/Product.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/product/entity/Product.java
@@ -38,7 +38,7 @@ public class Product extends BaseEntity {  // BaseEntity가 등록시간, 수정
 
     // 논리적 삭제를 위한 필드
     @Column
-    private boolean isDeleted = false;
+    private boolean isDeleted = false;  // true : 1,  false : 0
 
     // 상품 삭제 시 이미지 DB 도 같이 삭제 , cascade 옵션
     @OneToMany(mappedBy = "product", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/product/repository/ProductLikeCountRepository.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/product/repository/ProductLikeCountRepository.java
@@ -2,6 +2,7 @@ package com.jjs.ClothingInventorySaleReformPlatform.domain.product.repository;
 
 import com.jjs.ClothingInventorySaleReformPlatform.domain.product.entity.ProductLikeCount;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -9,4 +10,7 @@ import java.util.Optional;
 public interface ProductLikeCountRepository extends JpaRepository<ProductLikeCount, Long> {
     Optional<ProductLikeCount> findByProductId(Long productId);  // 상품 id로 좋아요 집계 정보 조회
     List<ProductLikeCount> findAllByOrderByLikeCountDesc();  // ProductLikeCount 엔티티를 좋아요 개수의 내림차순으로 정렬하여 가져옴
+
+    @Query("select plc from ProductLikeCount plc where plc.product.isDeleted = false order by plc.likeCount desc ")
+    List<ProductLikeCount> findAllByProductIsDeletedFalseOrderByLikeCountDesc();
 }

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/product/repository/ProductRepository.java
@@ -14,4 +14,10 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     List<Product> findByCategoryId(Long categoryId);  // 카테고리 ID를 기반으로 상품을 조회
 
     Optional<Product> findById(Long id);
+
+    // 삭제된 상품은 조회에 포함되지 않음
+    List<Product> findByCreateByAndIsDeletedFalse(String createBy);  // createBy로 필터링하고, isDeleted가 false인 상품들만 조회
+    List<Product> findByIsDeletedFalse();
+    Optional<Product> findByIdAndIsDeletedFalse(Long id);
+    List<Product> findByCategoryIdAndIsDeletedFalse(Long categoryId);
 }

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/product/service/ProductLikeCountService.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/product/service/ProductLikeCountService.java
@@ -60,11 +60,11 @@ public class ProductLikeCountService {
     }
 
     /**
-     * 상품들을 좋아요 개수 순서로 내림차순 정렬하여 목록으로 조회
+     * 상품들을 좋아요 개수 순서로 내림차순 정렬하여 목록으로 조회, 삭제된 상품 제외
      * @return
      */
     public List<ProductListLikeDTO> getProductsOrderByLikeCountDesc() {
-        List<ProductLikeCount> likeCounts = productLikeCountRepository.findAllByOrderByLikeCountDesc();
+        List<ProductLikeCount> likeCounts = productLikeCountRepository.findAllByProductIsDeletedFalseOrderByLikeCountDesc();
         return likeCounts.stream()
                 .map(likeCount -> productsFindAll(likeCount.getProduct(), likeCount.getLikeCount()))
                 .collect(Collectors.toList());

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/product/service/ProductService.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/product/service/ProductService.java
@@ -67,11 +67,11 @@ public class ProductService {
         Product product = productRepository.findById(productId)
                 .orElseThrow(() -> new EntityNotFoundException("Product not found"));
 
-        // 상품 정보 삭제
-        productRepository.delete(product);
+        // 상품 정보 삭제(삭제 여부를 true로 설정)
+        product.setDeleted(true);
 
         // S3에서 이미지 파일 삭제 로직은 별도 메소드로 분리될 수 있음
-        productImgService.deleteImagesFromS3(product.getProductImg());
+        //productImgService.deleteImagesFromS3(product.getProductImg());
     }
 
     // 상품 수정 - 게시글 수정 시, 기존의 이미지를 삭제하고 새로운 이미지를 추가하는 방식

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/product/service/ProductService.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/product/service/ProductService.java
@@ -91,18 +91,12 @@ public class ProductService {
 
     // 로그인한 판매자가 등록한 전체 상품 조회
     public List<ProductListDTO> getProductsFindAll(String createBy) {
-        List<Product> products = productRepository.findByCreateBy(createBy);
+        List<Product> products = productRepository.findByCreateByAndIsDeletedFalse(createBy);
         return products.stream().map(product -> {
             Long likeCount = productLikeCountRepository.findByProductId(product.getId())
                     .map(ProductLikeCount::getLikeCount).orElse(0L); // 상품 ID를 기준으로 좋아요 개수 조회
             return productsFindAll(product, likeCount); // 상품 정보와 좋아요 개수를 포함하여 DTO 변환
         }).collect(Collectors.toList());
-        /*
-        return productRepository.findByCreateBy(createBy)
-                .stream()
-                .map(this::productsFindAll)
-                .collect(Collectors.toList());
-         */
     }
     private ProductListDTO productsFindAll(Product product, Long likeCount) {  // 상품 전체 조회 dto
         ProductListDTO dto = new ProductListDTO();
@@ -148,18 +142,12 @@ public class ProductService {
 
     // 판매자들이 등록한 상품들 전체 조회(모든 상품)
     public List<ProductListDTO> getAllProducts() {
-        List<Product> products = productRepository.findAll();
+        List<Product> products = productRepository.findByIsDeletedFalse();
         return products.stream().map(product -> {
             Long likeCount = productLikeCountRepository.findByProductId(product.getId())
                     .map(ProductLikeCount::getLikeCount).orElse(0L); // 없는 경우 0으로 처리
             return productsFindAll(product, likeCount); // 상품 정보와 좋아요 개수를 DTO로 변환
         }).collect(Collectors.toList());
-        /*
-        return productRepository.findAll()
-                .stream()
-                .map(this::productsFindAll)
-                .collect(Collectors.toList());
-         */
     }
 
     // 특정 검색어가 포함된 상품들 전체 조회
@@ -180,13 +168,13 @@ public class ProductService {
 
     // 상품 상세 조회
     public Optional<ProductDetailDTO> getProductsFindDetail(Long productId) {
-        return productRepository.findById(productId)
+        return productRepository.findByIdAndIsDeletedFalse(productId)
                 .map(this::productsFindOne);
     }
 
     // 카테고리별 상품 조회
     public List<ProductListDTO> getProductsByCategory(Long categoryId) {
-        List<Product> products = productRepository.findByCategoryId(categoryId);
+        List<Product> products = productRepository.findByCategoryIdAndIsDeletedFalse(categoryId);
         return products.stream().map(product -> {
             Long likeCount = productLikeCountRepository.findByProductId(product.getId())
                     .map(ProductLikeCount::getLikeCount).orElse(0L); // 상품 ID를 기준으로 좋아요 개수 조회


### PR DESCRIPTION
# 🚀 개요
상품 테이블에 is_deleted라는 boolean 필드를 추가하여 초기값은 false로 하고 상품이 삭제되면 true로 변경하여 조회 로직에서는 true인 것들만 조회되도록 코드 수정.
전환 이유 : 판매자가 등록한 상품을 구매자가 구매했다. 근데 판매자가 상품을 삭제하면 구매자가 주문한 상품 또한 삭제된다. 이를 해결하기 위해서 실제로 삭제되는 DELETE를 사용하지 않고 상태를 변경함으로써 사용자들에게 안보이게 설정하는 방식을 선택했다.

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- product 엔티티에 is_deleted 플래그 값 추가
- 상품 및 장바구니 내 상품 조회 API들 수정

## ⏳ 작업 내용
- [x] product 엔티티에 is_deleted 플래그 값 추가
- [x] 상품 및 장바구니 내 상품 조회 API들 수정

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
