### PR TITLE
Feature/73 디자이너의 포트폴리오에 작업물 등록 API

### DIFF
--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/controller/ReformOutputController.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/controller/ReformOutputController.java
@@ -70,4 +70,19 @@ public class ReformOutputController {
             return response.fail(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
+
+    @Operation(summary = "작업물 수정 API", description = "제목과 내용을 포함하는 DTO를 사용하여 나머지 고정 항목들을 건드리지 않고 유연하게 수정한다.")
+    @PatchMapping(value = "/portfolio/reformOutput/edit/{progressNumber}")
+    public ResponseEntity<?> editContentsReformOutput(@Valid @RequestBody ReformOutputDTO reformOutputDTO, @PathVariable Long progressNumber) {
+        try {
+            reformOutputService.editReformOutput(reformOutputDTO, progressNumber);
+            return response.success("포트폴리오 작업물 수정 성공.", HttpStatus.OK);
+        } catch (IllegalArgumentException e) {
+            log.error("IllegalArgumentException");
+            return response.fail(e.getMessage(), HttpStatus.CONFLICT);
+        } catch (Exception e) {
+            log.error("포트폴리오 작업물 수정 실페",e);
+            return response.fail(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
 }

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/controller/ReformOutputController.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/controller/ReformOutputController.java
@@ -1,6 +1,7 @@
 package com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.controller;
 
 import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.request.ReformOutputDTO;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.response.EditContentsReformOutputDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.response.FixedReformOutputDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.entity.ReformOutput;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.service.ReformOutputService;
@@ -40,12 +41,27 @@ public class ReformOutputController {
         }
     }
 
-    @Operation(summary = "포트폴리오 작업물 등록 시, 고정 항목 조회", description = "디자이너가 작업물 등록 시, 직접 작성하는 항목을 제외한 나머지 항목들을 확인할 수 있다.")
+    @Operation(summary = "포트폴리오 작업물 등록 및 수정 시, 고정 항목 조회", description = "디자이너가 작업물 등록 시, 직접 작성하는 항목을 제외한 나머지 항목들을 확인할 수 있다.")
     @GetMapping(value = "/portfolio/reformOutput/upload/{progressNumber}")
     public ResponseEntity<?> getUploadReformOutput(@PathVariable Long progressNumber) {
         try {
             FixedReformOutputDTO fixedReformOutputDTO = reformOutputService.getReformOutputByProgressId(progressNumber);
             return response.success(fixedReformOutputDTO, "포드폴리오 작업물 등록 시, 고정 항목 조회 완료", HttpStatus.OK);
+        } catch (IllegalArgumentException e) {
+            log.error("IllegalArgumentException");
+            return response.fail(e.getMessage(), HttpStatus.CONFLICT);
+        } catch (Exception e) {
+            log.error("Exception", e);
+            return response.fail(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @Operation(summary = "작업물 수정 시, 이전에 작성했던 정보(제목, 내용) 조회", description = "디자이너가 작업물 수정을 하기위해 수정 페이지에 왔을 때, 전에 작성했던 내용을 수정해야되기 때문에 이전에 작성했던 내용들을 불러와야 한다.")
+    @GetMapping(value = "/portfolio/reformOutput/edit/{progressNumber}")
+    public ResponseEntity<?> getEditContentsReformOutput(@PathVariable Long progressNumber) {
+        try {
+            EditContentsReformOutputDTO editContentsReformOutputDTO = reformOutputService.getEditContentsByProgressId(progressNumber);
+            return response.success(editContentsReformOutputDTO, "포드폴리오 작업물 등록 시, 변동 항목 조회 완료", HttpStatus.OK);
         } catch (IllegalArgumentException e) {
             log.error("IllegalArgumentException");
             return response.fail(e.getMessage(), HttpStatus.CONFLICT);

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/controller/ReformOutputController.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/controller/ReformOutputController.java
@@ -1,8 +1,10 @@
 package com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.controller;
 
+import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.PortfolioInfoDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.request.ReformOutputDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.response.EditContentsReformOutputDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.response.FixedReformOutputDTO;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.response.ReformOutputDetailDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.entity.ReformOutput;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.service.ReformOutputService;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.dto.request.ReformRequestDTO;
@@ -16,6 +18,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
@@ -82,6 +86,21 @@ public class ReformOutputController {
             return response.fail(e.getMessage(), HttpStatus.CONFLICT);
         } catch (Exception e) {
             log.error("포트폴리오 작업물 수정 실페",e);
+            return response.fail(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @Operation(summary = "작업물 상세 조회", description = "모든 사용자들이 작업물의 내용을 조회할 수 있다.")
+    @GetMapping(value = "/portfolio/reformOutput/detail/{progressNumber}")
+    public ResponseEntity<?> getReformOutputDetail(@PathVariable Long progressNumber) {
+        try {
+            Optional<ReformOutputDetailDTO> reformOutputDetail = reformOutputService.getReformOutput(progressNumber);
+            return response.success(reformOutputDetail, "포드폴리오 작업물 등록 시, 변동 항목 조회 완료", HttpStatus.OK);
+        } catch (IllegalArgumentException e) {
+            log.error("IllegalArgumentException");
+            return response.fail(e.getMessage(), HttpStatus.CONFLICT);
+        } catch (Exception e) {
+            log.error("Exception", e);
             return response.fail(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/controller/ReformOutputController.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/controller/ReformOutputController.java
@@ -1,0 +1,57 @@
+package com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.controller;
+
+import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.request.ReformOutputDTO;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.response.FixedReformOutputDTO;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.entity.ReformOutput;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.service.ReformOutputService;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.dto.request.ReformRequestDTO;
+import com.jjs.ClothingInventorySaleReformPlatform.global.common.returnResponse.Response;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "디자이너 포트폴리오 작업물", description = "포트폴리오 작업물 API 입니다.")
+public class ReformOutputController {
+
+    private final Response response;
+    private final ReformOutputService reformOutputService;
+
+    @Operation(summary = "포트폴리오 작업물 등록", description = "디자이너의 리폼 진행이 끝나면 형상관리 id로 작업물들을 등록한다.")
+    @PostMapping(value = "/portfolio/reformOutput/upload/{progressNumber}")
+    public ResponseEntity<?> uploadReformOutput(@Valid @RequestBody ReformOutputDTO reformOutputDTO, @PathVariable Long progressNumber) {
+        try {
+            reformOutputService.saveReformOutput(reformOutputDTO, progressNumber);
+            return response.success("포트폴리오 작업물 등록 성공.", HttpStatus.OK);
+        } catch (IllegalArgumentException e) {
+            log.error("IllegalArgumentException");
+            return response.fail(e.getMessage(), HttpStatus.CONFLICT);
+        } catch (Exception e) {
+            log.error("포트폴리오 작업물 저장 실페",e);
+            return response.fail(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @Operation(summary = "포트폴리오 작업물 등록 시, 고정 항목 조회", description = "디자이너가 작업물 등록 시, 직접 작성하는 항목을 제외한 나머지 항목들을 확인할 수 있다.")
+    @GetMapping(value = "/portfolio/reformOutput/upload/{progressNumber}")
+    public ResponseEntity<?> getUploadReformOutput(@PathVariable Long progressNumber) {
+        try {
+            FixedReformOutputDTO fixedReformOutputDTO = reformOutputService.getReformOutputByProgressId(progressNumber);
+            return response.success(fixedReformOutputDTO, "포드폴리오 작업물 등록 시, 고정 항목 조회 완료", HttpStatus.OK);
+        } catch (IllegalArgumentException e) {
+            log.error("IllegalArgumentException");
+            return response.fail(e.getMessage(), HttpStatus.CONFLICT);
+        } catch (Exception e) {
+            log.error("Exception", e);
+            return response.fail(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/controller/ReformOutputController.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/controller/ReformOutputController.java
@@ -1,13 +1,11 @@
 package com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.controller;
 
-import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.PortfolioInfoDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.request.ReformOutputDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.response.EditContentsReformOutputDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.response.FixedReformOutputDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.response.ReformOutputDetailDTO;
-import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.entity.ReformOutput;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.response.ReformOutputListDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.service.ReformOutputService;
-import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.dto.request.ReformRequestDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.global.common.returnResponse.Response;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -15,10 +13,10 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Optional;
 
 @RestController
@@ -95,13 +93,24 @@ public class ReformOutputController {
     public ResponseEntity<?> getReformOutputDetail(@PathVariable Long progressNumber) {
         try {
             Optional<ReformOutputDetailDTO> reformOutputDetail = reformOutputService.getReformOutput(progressNumber);
-            return response.success(reformOutputDetail, "포드폴리오 작업물 등록 시, 변동 항목 조회 완료", HttpStatus.OK);
+            return response.success(reformOutputDetail, "포트폴리오 작업물 등록 시, 변동 항목 조회 완료", HttpStatus.OK);
         } catch (IllegalArgumentException e) {
             log.error("IllegalArgumentException");
             return response.fail(e.getMessage(), HttpStatus.CONFLICT);
         } catch (Exception e) {
             log.error("Exception", e);
             return response.fail(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @Operation(summary = "포트폴리오 작업물들 조회", description = "모든 사용자들이 작업물들을 리스트로 조회할 수 있다. 리스트의 항목으로는 결과물 사진과 제목이 포함된다.")
+    @GetMapping(value = "/portfolio/reformOutput/list")
+    public ResponseEntity<?> getAllReformOutputs() {
+        try {
+            List<ReformOutputListDTO> reformOutputs = reformOutputService.getAllReformOutputs();
+            return response.success(reformOutputs, "포트폴리오 작업물들 조회 완료", HttpStatus.OK);
+        } catch (Exception e) {
+            return response.fail(e.getMessage(), "포트폴리오 작업물들 조회 실패", HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/dto/request/ReformOutputDTO.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/dto/request/ReformOutputDTO.java
@@ -1,0 +1,12 @@
+package com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ReformOutputDTO {
+
+    private String title; // 제목
+    private String explanation;  // 내용
+}

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/dto/request/ReformPeriodDTO.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/dto/request/ReformPeriodDTO.java
@@ -1,0 +1,14 @@
+package com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+public class ReformPeriodDTO {
+
+    private LocalDate requestStartDate;
+    private LocalDate completeDate;
+}

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/dto/response/EditContentsReformOutputDTO.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/dto/response/EditContentsReformOutputDTO.java
@@ -1,0 +1,12 @@
+package com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.response;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class EditContentsReformOutputDTO {
+
+    private String title; // 제목
+    private String explanation;  // 내용
+}

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/dto/response/FixedReformOutputDTO.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/dto/response/FixedReformOutputDTO.java
@@ -1,0 +1,20 @@
+package com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.response;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class FixedReformOutputDTO {
+
+    private String designerName;  // 디자이너 명
+
+    private String productImgUrl;  // 리폼 전 사진 - 상품 사진 -> 형상관리의 productImgUrl
+    private String reformRequestImgUrl;  // 구매자 요청 사진 -> 요청서에서 [0]사진만 가져옴
+    private String estimateImgUrl;  // 디자이너 견적서 사진 -> 견적서에서 가져옴
+    private String completeImgUrl;  // 리폼 완료 사진 -> 형상관리에서 completeImgUrl
+
+    private String workingPeriod;  // 리폼 기간 -> 형상관리 엔티티 마지막 업데이트일 - 요청서 엔티티의 등록일
+    private String category;  // 리폼 부위
+    private int price;  // 리폼 가격
+}

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/dto/response/ReformOutputDetailDTO.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/dto/response/ReformOutputDetailDTO.java
@@ -1,0 +1,27 @@
+package com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+public class ReformOutputDetailDTO {  // 작업물 상세 조회
+
+    private String designerName;  // 디자이너 명
+    private String title; // 제목
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd")
+    private LocalDate date;  // 작성일
+
+    private String productImgUrl;  // 리폼 전 사진 - 상품 사진 -> 형상관리의 productImgUrl
+    private String reformRequestImgUrl;  // 구매자 요청 사진 -> 요청서에서 [0]사진만 가져옴
+    private String estimateImgUrl;  // 디자이너 견적서 사진 -> 견적서에서 가져옴
+    private String completeImgUrl;  // 리폼 완료 사진 -> 형상관리에서 completeImgUrl
+
+    private String workingPeriod;  // 리폼 기간 -> 형상관리 엔티티 마지막 업데이트일 - 요청서 엔티티의 등록일
+    private String category;  // 리폼 부위
+    private int price;  // 리폼 가격
+    private String explanation;  // 내용
+}

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/dto/response/ReformOutputListDTO.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/dto/response/ReformOutputListDTO.java
@@ -1,0 +1,21 @@
+package com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.response;
+
+import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.entity.ReformOutput;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ReformOutputListDTO {
+
+    private String title; // 제목
+    private String completeImgUrl;  // 리폼 완료 사진 -> 형상관리에서 completeImgUrl
+
+    public static ReformOutputListDTO convertToDTO(ReformOutput reformOutput) {
+        ReformOutputListDTO reformOutputListDTO = new ReformOutputListDTO();
+        reformOutputListDTO.setCompleteImgUrl(reformOutput.getCompleteImgUrl());
+        reformOutputListDTO.setTitle(reformOutput.getTitle());
+
+        return  reformOutputListDTO;
+    }
+}

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/entity/ReformOutput.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/entity/ReformOutput.java
@@ -1,0 +1,75 @@
+package com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.entity;
+
+import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.entity.progressManagement.Progressmanagement;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "OUTPUT")
+public class ReformOutput {
+    /**
+     * 형상관리 번호로 작성 가능해야 함 -> 디자이너는 리폼 완료 후 해당 리폼 구역의 버튼으로 작업물 등록이 가능하도록 해야 함.
+     */
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "OUTPUT_ID", nullable = false)
+    private Long id;
+
+    @Column(name = "TITLE")
+    private String title;  // 제목
+
+    @Column(name = "DESIGNER_NAME")
+    private String name;  // 디자이너명
+
+    private String productImgUrl;  // 리폼 전 사진 - 상품 사진 -> 형상관리의 productImgUrl
+    private String reformRequestImgUrl;  // 구매자 요청 사진 -> 요청서에서 [0]사진만 가져옴
+    private String estimateImgUrl;  // 디자이너 견적서 사진 -> 견적서에서 가져옴
+    private String completeImgUrl;  // 리폼 완료 사진 -> 형상관리에서 completeImgUrl
+
+    @NotNull
+    @Column(name = "WORKING_PERIOD")
+    private String workingPeriod;  // 리폼 기간 -> 형상관리 엔티티 마지막 업데이트일 - 요청서 엔티티의 등록일
+
+    @NotNull
+    @Column(name = "CATEGORY")
+    private String category;  // 리폼 부위
+
+    @NotNull
+    @Column(name = "PRICE")
+    private int price;  // 리폼 가격
+
+    @NotNull
+    @Column(name = "EXPLANATION", nullable = false, length = 1000)  // @Lob는 매우 큰 데이터(Mb 단위)를 저장할 때 사용한다고 하여 varchar(1000)으로 수정함
+    private String explanation;  // 작업물 내용 작성
+
+    @NotNull
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "PROGRESS_NUMBER")
+    private Progressmanagement progress; // Progressmanagement 엔티티 참조
+
+
+    /**
+     * 리폼 기간을 계산하여 설정하는 메서드.
+     * @param requestStartDate 리폼 요청 시작 날짜
+     * @param completeDate 리폼 완료 날짜
+     */
+    public String calWorkingPeriod(LocalDate requestStartDate, LocalDate completeDate) {
+        if (requestStartDate != null && completeDate != null) {
+            long days = ChronoUnit.DAYS.between(completeDate, requestStartDate) + 1;
+            return String.valueOf(days) + "일";
+        } else {
+            return null;
+        }
+    }
+
+
+}
+

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/entity/ReformOutput.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/entity/ReformOutput.java
@@ -1,6 +1,7 @@
 package com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.entity;
 
 import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.entity.progressManagement.Progressmanagement;
+import com.jjs.ClothingInventorySaleReformPlatform.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -13,7 +14,7 @@ import java.time.temporal.ChronoUnit;
 @Setter
 @Entity
 @Table(name = "OUTPUT")
-public class ReformOutput {
+public class ReformOutput extends BaseEntity {
     /**
      * 형상관리 번호로 작성 가능해야 함 -> 디자이너는 리폼 완료 후 해당 리폼 구역의 버튼으로 작업물 등록이 가능하도록 해야 함.
      */

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/repository/ReformOutputRepository.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/repository/ReformOutputRepository.java
@@ -1,0 +1,7 @@
+package com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.repository;
+
+import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.entity.ReformOutput;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReformOutputRepository extends JpaRepository<ReformOutput, Long> {
+}

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/repository/ReformOutputRepository.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/repository/ReformOutputRepository.java
@@ -3,5 +3,9 @@ package com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.repository;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.entity.ReformOutput;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ReformOutputRepository extends JpaRepository<ReformOutput, Long> {
+
+    Optional<ReformOutput> findByProgress_id(Long progressNumber);
 }

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/repository/ReformOutputRepository.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/repository/ReformOutputRepository.java
@@ -3,9 +3,11 @@ package com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.repository;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.entity.ReformOutput;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ReformOutputRepository extends JpaRepository<ReformOutput, Long> {
 
     Optional<ReformOutput> findByProgress_id(Long progressNumber);
+    List<ReformOutput> findAll();
 }

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/service/ReformOutputService.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/service/ReformOutputService.java
@@ -122,7 +122,15 @@ public class ReformOutputService {
         return editContentsReformOutputDTO;
     }
 
+    public void editReformOutput(ReformOutputDTO reformOutputDTO, Long progressNumber) {
+        ReformOutput reformOutput = reformOutputRepository.findByProgress_id(progressNumber)
+                .orElseThrow(() -> new IllegalArgumentException("progressId에 해당되는 작업물 없음"));
 
+        reformOutput.setTitle(reformOutputDTO.getTitle());
+        reformOutput.setExplanation(reformOutputDTO.getExplanation());
+
+        reformOutputRepository.save(reformOutput);
+    }
 
 
 }

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/service/ReformOutputService.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/service/ReformOutputService.java
@@ -5,6 +5,7 @@ import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.request.
 import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.response.EditContentsReformOutputDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.response.FixedReformOutputDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.response.ReformOutputDetailDTO;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.response.ReformOutputListDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.entity.Portfolio;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.entity.ReformOutput;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.repository.PortfolioRepository;
@@ -24,7 +25,9 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -154,5 +157,12 @@ public class ReformOutputService {
         reformOutputDetailDTO.setExplanation(reformOutput.getExplanation());
 
         return Optional.of(reformOutputDetailDTO);
+    }
+
+    public List<ReformOutputListDTO> getAllReformOutputs() {
+        List<ReformOutput> reformOutputs = reformOutputRepository.findAll();
+        return reformOutputs.stream()
+                .map(ReformOutputListDTO::convertToDTO)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/service/ReformOutputService.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/service/ReformOutputService.java
@@ -4,6 +4,7 @@ import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.request.
 import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.request.ReformPeriodDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.response.EditContentsReformOutputDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.response.FixedReformOutputDTO;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.response.ReformOutputDetailDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.entity.Portfolio;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.entity.ReformOutput;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.repository.PortfolioRepository;
@@ -23,6 +24,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -132,5 +134,25 @@ public class ReformOutputService {
         reformOutputRepository.save(reformOutput);
     }
 
+    public Optional<ReformOutputDetailDTO> getReformOutput(Long progressNumber) {
+        ReformOutput reformOutput = reformOutputRepository.findByProgress_id(progressNumber)
+                .orElseThrow(() -> new IllegalArgumentException("progressId에 해당되는 작업물 없음"));
 
+        ReformOutputDetailDTO reformOutputDetailDTO = new ReformOutputDetailDTO();
+        reformOutputDetailDTO.setDesignerName(reformOutput.getName());
+        reformOutputDetailDTO.setTitle(reformOutput.getTitle());
+        reformOutputDetailDTO.setDate(reformOutput.getRegDate().toLocalDate());
+
+        reformOutputDetailDTO.setProductImgUrl(reformOutput.getProductImgUrl());
+        reformOutputDetailDTO.setReformRequestImgUrl(reformOutput.getReformRequestImgUrl());
+        reformOutputDetailDTO.setEstimateImgUrl(reformOutput.getEstimateImgUrl());
+        reformOutputDetailDTO.setCompleteImgUrl(reformOutput.getCompleteImgUrl());
+
+        reformOutputDetailDTO.setWorkingPeriod(reformOutput.getWorkingPeriod());
+        reformOutputDetailDTO.setCategory(reformOutput.getCategory());
+        reformOutputDetailDTO.setPrice(reformOutput.getPrice());
+        reformOutputDetailDTO.setExplanation(reformOutput.getExplanation());
+
+        return Optional.of(reformOutputDetailDTO);
+    }
 }

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/service/ReformOutputService.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/service/ReformOutputService.java
@@ -2,6 +2,7 @@ package com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.service;
 
 import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.request.ReformOutputDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.request.ReformPeriodDTO;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.response.EditContentsReformOutputDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.response.FixedReformOutputDTO;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.entity.Portfolio;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.entity.ReformOutput;
@@ -34,8 +35,6 @@ public class ReformOutputService {
     private final ReformRequestRepository reformRequestRepository;
     private final ProgressRepository progressRepository;
     private final ReformOutputRepository reformOutputRepository;
-
-    private String imageUploadPath = "ReformOutputImages/";
 
     private String getCurrentUsername() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
@@ -82,7 +81,7 @@ public class ReformOutputService {
     }
 
     /**
-     * 포트폴리오 작업물 등록 시, 고정 항목 조회
+     * 포트폴리오 작업물 등록 및 수정 시, 고정 항목 조회
      * @param progressNumber 형상관리 id
      * @return fixedReformOutputDTO
      */
@@ -108,10 +107,19 @@ public class ReformOutputService {
         LocalDate endDate = progress.getUpdateDate().toLocalDate();
         ReformOutput reformOutput = new ReformOutput();
         fixedReformOutputDTO.setWorkingPeriod(reformOutput.calWorkingPeriod(startDate, endDate));
-        //System.out.println("startDate: " + startDate + "  endDate: " + endDate);
 
         return fixedReformOutputDTO;
+    }
 
+    public EditContentsReformOutputDTO getEditContentsByProgressId(Long progressNumber) {
+        ReformOutput reformOutput = reformOutputRepository.findByProgress_id(progressNumber)
+                .orElseThrow(() -> new IllegalArgumentException("progressId에 해당되는 작업물 없음"));
+
+        EditContentsReformOutputDTO editContentsReformOutputDTO = new EditContentsReformOutputDTO();
+        editContentsReformOutputDTO.setTitle(reformOutput.getTitle());
+        editContentsReformOutputDTO.setExplanation(reformOutput.getExplanation());
+
+        return editContentsReformOutputDTO;
     }
 
 

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/service/ReformOutputService.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/portfolio/service/ReformOutputService.java
@@ -1,0 +1,120 @@
+package com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.service;
+
+import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.request.ReformOutputDTO;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.request.ReformPeriodDTO;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.dto.response.FixedReformOutputDTO;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.entity.Portfolio;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.entity.ReformOutput;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.repository.PortfolioRepository;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.portfolio.repository.ReformOutputRepository;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.entity.estimate.Estimate;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.entity.progressManagement.Progressmanagement;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.entity.reformRequest.ReformRequest;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.repository.ProgressRepository;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.repository.ReformRequestRepository;
+import com.jjs.ClothingInventorySaleReformPlatform.global.common.authentication.AuthenticationFacade;
+import com.jjs.ClothingInventorySaleReformPlatform.global.s3.S3Service;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cglib.core.Local;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ReformOutputService {
+
+    private final PortfolioRepository portfolioRepository;
+    private final S3Service s3Service;
+    private final AuthenticationFacade authenticationFacade;
+    private final ReformRequestRepository reformRequestRepository;
+    private final ProgressRepository progressRepository;
+    private final ReformOutputRepository reformOutputRepository;
+
+    private String imageUploadPath = "ReformOutputImages/";
+
+    private String getCurrentUsername() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.isAuthenticated()) {
+            return authentication.getName();
+        }
+        return null;
+    }
+
+    /**
+     * 디자이너 포트폴리오 작업물 등록
+     * @param reformOutputDTO 제목, 내용 직접 입력, 나머지는 자동 기입
+     * @param progressNumber  형상관리 id에 대하여 생성됨
+     */
+    public void saveReformOutput(ReformOutputDTO reformOutputDTO, Long progressNumber) {
+
+        Progressmanagement progress = progressRepository.findById(progressNumber)
+                .orElseThrow(() -> new IllegalArgumentException("progressId에 해당되는 형상관리 없음"));
+        ReformRequest reformRequest = progress.getRequestNumber();  // 요청서
+        Estimate estimate = progress.getEstimateNumber();  // 견적서
+        String designerEmail = getCurrentUsername();
+        Portfolio portfolio = portfolioRepository.findByDesignerEmail_Email(designerEmail)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다."));
+        ReformOutput reformOutput = new ReformOutput();
+
+        LocalDate startDate = reformRequest.getRegDate().toLocalDate();
+        LocalDate endDate = progress.getUpdateDate().toLocalDate();
+
+        reformOutput.setName(portfolio.getName());  // 디자이너명
+        reformOutput.setProductImgUrl(progress.getProductImgUrl());  // 초기 사진(상품 사진 → 형상관리1)
+        reformOutput.setReformRequestImgUrl(String.valueOf(reformRequest.getReformRequestImageList().get(0).getImgUrl()));  // 구매자 요청 사진(요청서)
+        reformOutput.setEstimateImgUrl(String.valueOf(estimate.getEstimateImg().get(0).getImgUrl()));  // 디자이너 견적 사진(견적서)
+        reformOutput.setCompleteImgUrl(progress.getCompleteImgUrl());  // 완성 사진(형상관리4)
+        reformOutput.setWorkingPeriod(reformOutput.calWorkingPeriod(startDate, endDate));  // 리폼 기간(일수→시작일: 요청서, 완료일: 형상관리 마지막 업데이트)
+        reformOutput.setPrice(estimate.getPrice());  // 리폼 가격(견적서)
+        reformOutput.setCategory(reformRequest.getProductNumber().getCategory().getCategoryName());  // 리폼 부위(요청서)
+        reformOutput.setProgress(progress);
+
+        reformOutput.setTitle(reformOutputDTO.getTitle());  // 제목(직접 입력)
+        reformOutput.setExplanation(reformOutputDTO.getExplanation());  // 내용(직접 입력)
+
+        reformOutputRepository.save(reformOutput);
+
+    }
+
+    /**
+     * 포트폴리오 작업물 등록 시, 고정 항목 조회
+     * @param progressNumber 형상관리 id
+     * @return fixedReformOutputDTO
+     */
+    public FixedReformOutputDTO getReformOutputByProgressId(Long progressNumber) {
+        Progressmanagement progress = progressRepository.findById(progressNumber)
+                .orElseThrow(() -> new IllegalArgumentException("progressId에 해당되는 형상관리 없음"));
+        ReformRequest reformRequest = progress.getRequestNumber();  // 요청서
+        Estimate estimate = progress.getEstimateNumber();  // 견적서
+        String designerEmail = getCurrentUsername();
+        Portfolio portfolio = portfolioRepository.findByDesignerEmail_Email(designerEmail)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다."));
+
+        FixedReformOutputDTO fixedReformOutputDTO = new FixedReformOutputDTO();
+        fixedReformOutputDTO.setDesignerName(portfolio.getName());
+        fixedReformOutputDTO.setProductImgUrl(progress.getProductImgUrl());
+        fixedReformOutputDTO.setReformRequestImgUrl(reformRequest.getReformRequestImageList().get(0).getImgUrl());
+        fixedReformOutputDTO.setEstimateImgUrl(String.valueOf(estimate.getEstimateImg().get(0).getImgUrl()));
+        fixedReformOutputDTO.setCompleteImgUrl(progress.getCompleteImgUrl());
+        fixedReformOutputDTO.setCategory(reformRequest.getProductNumber().getCategory().getCategoryName());
+        fixedReformOutputDTO.setPrice(estimate.getPrice());
+
+        LocalDate startDate = reformRequest.getRegDate().toLocalDate();
+        LocalDate endDate = progress.getUpdateDate().toLocalDate();
+        ReformOutput reformOutput = new ReformOutput();
+        fixedReformOutputDTO.setWorkingPeriod(reformOutput.calWorkingPeriod(startDate, endDate));
+        //System.out.println("startDate: " + startDate + "  endDate: " + endDate);
+
+        return fixedReformOutputDTO;
+
+    }
+
+
+
+
+}

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/reform/entity/progressManagement/Progressmanagement.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/reform/entity/progressManagement/Progressmanagement.java
@@ -2,6 +2,7 @@ package com.jjs.ClothingInventorySaleReformPlatform.domain.reform.entity.progres
 
 import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.entity.reformRequest.ReformRequest;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.entity.estimate.Estimate;
+import com.jjs.ClothingInventorySaleReformPlatform.global.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -11,7 +12,7 @@ import lombok.Setter;
 @Setter
 @Entity
 @Table(name = "ProgressManagement")
-public class Progressmanagement {
+public class Progressmanagement extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/reform/repository/ProgressRepository.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/reform/repository/ProgressRepository.java
@@ -10,5 +10,7 @@ public interface ProgressRepository extends JpaRepository<Progressmanagement, Lo
     Optional<Progressmanagement> findByEstimateNumber_Id(Long estimateNumber);  // EstimateNumber 필드의 id 속성을 사용하여 ProgressManagement 엔티티를 조회
     //Optional<Progressmanagement> findByEstimateNumber(Estimate estimate);  // Estimate 엔티티의 인스턴스를 먼저 조회한 다음, 이 인스턴스를 사용하여 ProgressManagement를 조회
 
+    // ID로 Progressmanagement 객체를 조회
+    Optional<Progressmanagement> findById(Long id);
 
 }

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/global/config/SecurityConfig.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/global/config/SecurityConfig.java
@@ -63,7 +63,7 @@ public class SecurityConfig{
                                 "/estimate/purchaser/**", "/progress/purchaser/img/**").hasRole("PURCHASER")
                         .requestMatchers("/auth/update-designer/address","/designer/portfolio/**",
                                 "/estimate/designer/estimateForm/**","/estimate/designer/requestForm/{requestNumber}",
-                                "/progress/designer/setImg/**", "/portfolio/reformOutput/upload/**").hasRole("DESIGNER")
+                                "/progress/designer/setImg/**", "/portfolio/reformOutput/upload/**", "/portfolio/reformOutput/edit/**").hasRole("DESIGNER")
                         .requestMatchers("/chat/**", "/chat", "/chatroom").hasAnyRole("PURCHASER","DESIGNER")
                         .anyRequest().authenticated());
 

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/global/config/SecurityConfig.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/global/config/SecurityConfig.java
@@ -63,7 +63,7 @@ public class SecurityConfig{
                                 "/estimate/purchaser/**", "/progress/purchaser/img/**").hasRole("PURCHASER")
                         .requestMatchers("/auth/update-designer/address","/designer/portfolio/**",
                                 "/estimate/designer/estimateForm/**","/estimate/designer/requestForm/{requestNumber}",
-                                "/progress/designer/setImg/**").hasRole("DESIGNER")
+                                "/progress/designer/setImg/**", "/portfolio/reformOutput/upload/**").hasRole("DESIGNER")
                         .requestMatchers("/chat/**", "/chat", "/chatroom").hasAnyRole("PURCHASER","DESIGNER")
                         .anyRequest().authenticated());
 

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/global/config/SecurityConfig.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/global/config/SecurityConfig.java
@@ -50,7 +50,7 @@ public class SecurityConfig{
                 .authorizeHttpRequests((auth) -> auth
                         .requestMatchers("/auth/login", "/auth/login-test", "/auth/reissue", "/", "/auth/join-purchaser", "/auth/join-seller", "/auth/join-designer",
                                 "/designer/portfolio","/swagger-ui/**","/v3/api-docs/**", "/swagger-resources/**",
-                                "/product/all/like/desc","/ws/chat/**", "/returnEstimateNumber/{reformRequest}").permitAll()
+                                "/product/all/like/desc","/ws/chat/**", "/returnEstimateNumber/{reformRequest}", "/portfolio/reformOutput/detail/{progressNumber}").permitAll()
                         .requestMatchers("/admin", "/auth/login-test", "/product/all", "/product/all/{keyword}", "/product/all/{productId}",
                                 "/product/all/detail/{productId}", "/product/category/{categoryId}", "/product/all/detail/{productId}/**",
                                 "/product/all/detail/{productId}/seller", "/user/role", "/auth/logout", "/auth/edit/**", "/auth/info/**",


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
디자이너는 리폼이 완료된 작업물을 자신의 포트폴리오에 등록할 수 있다. 리폼 완료 여부는 형상관리 마지막 사진이 등록되면 상태가 리폼 완료 상태가 되므로 형상관리id로 작업물이 생성된다.(작업물 생성 시 ProgressId가 필요하다.)

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 작업물 관련 API 추가

## ⏳ 작업 내용
- [x] #73 의 API들 추가


### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
