### PR TITLE
Refactor/77 견적서 작성 로직 수정

### DIFF
--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/reform/controller/EstimateController.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/reform/controller/EstimateController.java
@@ -60,7 +60,7 @@ public class EstimateController {
     }
 
     @PostMapping(value = "/estimate/designer/estimateForm/{requestNumber}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    @Operation(summary = "디자이너의 견적서 작성", description = "디자이너가 견적서를 작성합니다.")
+    @Operation(summary = "디자이너의 견적서 작성", description = "디자이너가 견적서를 작성 및 저장합니다. 저장 시 상태는 WRITING 입니다.")
     public ResponseEntity<?> sendEstimate(@ModelAttribute EstimateRequestDTO estimateRequestDTO, @PathVariable Long requestNumber) {
         try {
             estimateService.saveEstimate(estimateRequestDTO, requestNumber);

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/reform/entity/estimate/EstimateStatus.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/reform/entity/estimate/EstimateStatus.java
@@ -1,5 +1,5 @@
 package com.jjs.ClothingInventorySaleReformPlatform.domain.reform.entity.estimate;
 
 public enum EstimateStatus {
-    REQUEST_WAITING, REQUEST_REJECTED, REQUEST_ACCEPTED // 요청 대기중, 요청 거절, 요청 수락
+    WRITING, REQUEST_WAITING, REQUEST_REJECTED, REQUEST_ACCEPTED // 요청 대기중, 요청 거절, 요청 수락
 }

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/reform/repository/EstimateRepository.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/reform/repository/EstimateRepository.java
@@ -1,12 +1,15 @@
 package com.jjs.ClothingInventorySaleReformPlatform.domain.reform.repository;
 
 import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.entity.estimate.Estimate;
+import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.entity.estimate.EstimateStatus;
 import com.jjs.ClothingInventorySaleReformPlatform.domain.reform.entity.reformRequest.ReformRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import javax.swing.text.html.Option;
 import java.util.Optional;
 
 public interface EstimateRepository extends JpaRepository<Estimate, Long> {
     Optional<Estimate> findEstimateById(Long id);
     Optional<Estimate> findEstimateByRequestNumber(ReformRequest requestNumber);
+    Optional<Estimate> findByRequestNumberAndEstimateStatusNot(ReformRequest requestNumber, EstimateStatus status);
 }

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/reform/service/EstimateService.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/domain/reform/service/EstimateService.java
@@ -131,7 +131,7 @@ public class EstimateService {
         estimate.setPurchaserEmail(reformRequest.getPurchaserEmail());
         estimate.setDesignerEmail(reformRequest.getDesignerEmail());
         estimate.setRequestNumber(reformRequest);
-        estimate.setEstimateStatus(EstimateStatus.REQUEST_WAITING);
+        estimate.setEstimateStatus(EstimateStatus.WRITING);
 
         estimate.setEstimateInfo(estimateRequestDTO.getEstimateInfo());
         estimate.setReformPrice(estimateRequestDTO.getReformPrice());  // 리폼 비용
@@ -200,7 +200,7 @@ public class EstimateService {
         Estimate estimate = estimateRepository.findEstimateById(estimateNumber)
                 .orElseThrow(() -> new IllegalArgumentException("견적서가 존재하지 않습니다."));
 
-        if (estimate.getEstimateStatus() != EstimateStatus.REQUEST_WAITING) {
+        if (estimate.getEstimateStatus() != EstimateStatus.WRITING) {
             throw new RuntimeException("이미 진행 중인 의뢰로 수정이 불가합니다.");
         } else {
             List<EstimateImage> imageList = estimateImgRepository.findAllByEstimateId(estimateNumber);

--- a/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/global/config/SecurityConfig.java
+++ b/src/main/java/com/jjs/ClothingInventorySaleReformPlatform/global/config/SecurityConfig.java
@@ -60,11 +60,11 @@ public class SecurityConfig{
                         .requestMatchers("/cart/purchaser/add/{productId}", "/cart/purchaser/**", "/reform-request/purchaser/**",
                                 "/product/all/detail/{productId}/like", "/order/purchaser-list", "/auth/update-purchaser/address",
                                 "/reform/purchaser/requests/**",
-                                "/estimate/purchaser/**").hasRole("PURCHASER")
+                                "/estimate/purchaser/**", "/estimate/purchaser/estimateForm/{requestNumber}").hasRole("PURCHASER")
                         .requestMatchers("/auth/update-designer/address","/designer/portfolio/**",
                                 "/estimate/designer/estimateForm/**","/estimate/designer/requestForm/{requestNumber}",
                                 "/progress/designer/setImg/**", "/portfolio/reformOutput/upload/**", "/portfolio/reformOutput/edit/**").hasRole("DESIGNER")
-                        .requestMatchers("/chat/**", "/chat", "/chatroom", "/progress/img/**", "/estimate/estimateForm/{requestNumber}").hasAnyRole("PURCHASER","DESIGNER")
+                        .requestMatchers("/chat/**", "/chat", "/chatroom", "/progress/img/**").hasAnyRole("PURCHASER","DESIGNER")
                         .anyRequest().authenticated());
 
         http


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
견적서 작성 시, 작성과 제출을 분리하여 작성 시에는 상태가 작성중이 되도록 수정하고, 최종 제출 시 요청 대기중으로 상태가 변경되는 api를 추가함.
견적서 조회는 견적서의 상태가 작성중이면 구매자는 견적서 조회가 안되도록하는 api를 추가하고, 기존의 api는 상태 상관 없이 조회 가능하므로 권한을 디자이너에게 주도록 변경

## 🔍 변경사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 견적서 조회 api 디자이너와 구매자 분리 (구매자는 디자이너가 제출한 견적서만 조회 가능, 디자이너는 저장한 견적서까지 조회 가능)



### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
